### PR TITLE
[OrigamiUI] Fix FileDialog "Drives" overflowing for really long drive names

### DIFF
--- a/Origami/Origami/Widgets/FileDialog.cs
+++ b/Origami/Origami/Widgets/FileDialog.cs
@@ -366,7 +366,7 @@ public static class FileDialog
             var r = paper.Row(sid).Height(m.RowHeight)
                 .BackgroundColor(sel ? Selection : Color.Transparent)
                 .Hovered.BackgroundColor(sel ? Selection : theme.Hover).End()
-                .Rounded(6).ChildLeft(7).RowBetween(6);
+                .Rounded(6).ChildLeft(7).RowBetween(6).Clip();
             r.OnClick(0, (_, _) => NavigateTo(path, true));
             using (r.Enter())
             {


### PR DESCRIPTION
### Before
<img width="772" height="580" alt="Screenshot 2026-07-10 at 2 27 32 PM" src="https://github.com/user-attachments/assets/9bf2b815-930f-4e71-9722-78e46aeaea60" />

### After
<img width="833" height="575" alt="Screenshot 2026-07-10 at 3 06 59 PM" src="https://github.com/user-attachments/assets/79863e2f-6004-43d6-875a-e8b303e76c53" />
