### PR TITLE
Fix DrawFlagsMenu unchecking not working for composites

### DIFF
--- a/Origami/Origami/Widgets/PropertyGrid.cs
+++ b/Origami/Origami/Widgets/PropertyGrid.cs
@@ -615,12 +615,19 @@ public static class PropertyGridRenderer
             if ((valueU & u) == u) current.Add(v!);
         }
 
+        var before = new HashSet<ulong>();
+        foreach (var c in current) before.Add(Convert.ToUInt64(c));
+
         Origami.MultiDropdown<object>(paper, id, current,
             selected =>
             {
-                ulong combined = 0;
-                foreach (var f in selected) combined |= Convert.ToUInt64(f);
-                onChange(Enum.ToObject(enumType, combined));
+                var after = new HashSet<ulong>();
+                foreach (var f in selected) after.Add(Convert.ToUInt64(f));
+
+                ulong bits = valueU;
+                foreach (ulong u in before) if (!after.Contains(u)) bits &= ~u;
+                foreach (ulong u in after) if (!before.Contains(u)) bits |= u;
+                onChange(Enum.ToObject(enumType, bits));
             }, nonZero)
             .Display(o => Enum.GetName(enumType, o) ?? o.ToString() ?? "")
             .Show();


### PR DESCRIPTION
As the title states, modified the DrawFlagsMenu so that checking/unchecking works for composites as well. Or being used to detect a check/uncheck does not work for composites where their values are driven by other flags as well (e.g. rigidbody constraints).