### PR TITLE
Close tile-cache seams with bordered tiles and shared seam profiles

### DIFF
--- a/Recast/Recast/Detour.TileCache/DtTileCache.cs
+++ b/Recast/Recast/Detour.TileCache/DtTileCache.cs
@@ -48,6 +48,16 @@ namespace Prowl.Recast.Detour.TileCache
         private readonly IRcCompressor m_tcomp;
         private readonly IDtTileCacheMeshProcess m_tmproc;
 
+        /// Held for the life of the cache rather than made per tile: a context allocates
+        /// thread-local timer state, and tile builds run one at a time on a cache.
+        private readonly RcContext m_ctx = new RcContext();
+
+        /// Neighbour layers a tile's border reads, by tile ref (#BorderLayer). Dropped whenever a
+        /// tile or an obstacle changes, since both change what the layers say.
+        private readonly Dictionary<long, DtTileCacheLayer> m_borderLayers = new Dictionary<long, DtTileCacheLayer>();
+        private const int MaxCachedBorderLayers = 256;
+        private readonly List<long> m_neighbourRefs = new List<long>();
+
         private readonly List<DtTileCacheObstacle> m_obstacles = new List<DtTileCacheObstacle>();
         private DtTileCacheObstacle m_nextFreeObstacle;
 
@@ -167,7 +177,14 @@ namespace Prowl.Recast.Detour.TileCache
         public List<long> GetTilesAt(int tx, int ty)
         {
             List<long> tiles = new List<long>();
+            GetTilesAt(tx, ty, tiles);
+            return tiles;
+        }
 
+        /// The refs at a tile column, appended to @p tiles. Callers on the tile build path use
+        /// this rather than the allocating overload: it runs eight times per tile built.
+        public void GetTilesAt(int tx, int ty, List<long> tiles)
+        {
             // Find tile based on hash.
             int h = ComputeTileHash(tx, ty, m_tileLutMask);
             DtCompressedTile tile = m_posLookup[h];
@@ -180,8 +197,6 @@ namespace Prowl.Recast.Detour.TileCache
 
                 tile = tile.next;
             }
-
-            return tiles;
         }
 
         DtCompressedTile GetTileAt(int tx, int ty, int tlayer)
@@ -249,6 +264,8 @@ namespace Prowl.Recast.Detour.TileCache
 
         public long AddTile(byte[] data, int flags)
         {
+            m_borderLayers.Clear();
+
             // Make sure the data is in right format.
             RcByteBuffer buf = new RcByteBuffer(data);
             buf.Order(m_storageParams.Order);
@@ -295,6 +312,8 @@ namespace Prowl.Recast.Detour.TileCache
 
         public void RemoveTile(long refs)
         {
+            m_borderLayers.Clear();
+
             if (refs == 0)
             {
                 throw new Exception("Invalid tile ref");
@@ -509,6 +528,13 @@ namespace Prowl.Recast.Detour.TileCache
 
             if (0 == m_update.Count)
             {
+                // Cached neighbour layers carry the obstacles cut into them, which these
+                // requests are about to change.
+                if (m_reqs.Count > 0)
+                {
+                    m_borderLayers.Clear();
+                }
+
                 // Process requests.
                 foreach (DtObstacleRequest req in m_reqs)
                 {
@@ -527,10 +553,18 @@ namespace Prowl.Recast.Detour.TileCache
 
                     if (req.action == DtObstacleRequestAction.REQUEST_ADD)
                     {
-                        // Find touched tiles.
+                        // Find touched tiles. Widened by the seam border, because a tile reads
+                        // that far into its neighbours: a tile the obstacle only reaches through
+                        // its border still has to rebuild, or its seam keeps describing ground
+                        // the neighbour has already cut away.
                         RcVec3f bmin = new RcVec3f();
                         RcVec3f bmax = new RcVec3f();
                         GetObstacleBounds(ob, ref bmin, ref bmax);
+                        float reach = DtTileCacheBuilder.SeamBorder * m_params.cs;
+                        bmin.X -= reach;
+                        bmin.Z -= reach;
+                        bmax.X += reach;
+                        bmax.Z += reach;
 
                         int ntouched = 0;
                         QueryTiles(bmin, bmax, ob.touched, ref ntouched);
@@ -635,34 +669,31 @@ namespace Prowl.Recast.Detour.TileCache
             DtTileCacheLayer layer = DecompressTile(tile);
 
             // Rasterize obstacles.
-            for (int i = 0; i < m_obstacles.Count; ++i)
-            {
-                DtTileCacheObstacle ob = m_obstacles[i];
-                if (ob.state == DtObstacleState.DT_OBSTACLE_EMPTY || ob.state == DtObstacleState.DT_OBSTACLE_REMOVING)
-                {
-                    continue;
-                }
+            MarkObstacles(layer, tile.header.bmin, refs);
 
-                if (Contains(ob.touched, refs))
-                {
-                    if (ob.type == DtTileCacheObstacleType.DT_OBSTACLE_CYLINDER)
-                    {
-                        DtTileCacheBuilder.MarkCylinderArea(layer, tile.header.bmin, m_params.cs, m_params.ch, ob.cylinder.pos, ob.cylinder.radius, ob.cylinder.height, 0);
-                    }
-                    else if (ob.type == DtTileCacheObstacleType.DT_OBSTACLE_BOX)
-                    {
-                        DtTileCacheBuilder.MarkBoxArea(layer, tile.header.bmin, m_params.cs, m_params.ch, ob.box.bmin, ob.box.bmax, 0);
-                    }
-                    else if (ob.type == DtTileCacheObstacleType.DT_OBSTACLE_ORIENTED_BOX)
-                    {
-                        DtTileCacheBuilder.MarkBoxArea(layer, tile.header.bmin, m_params.cs, m_params.ch, ob.orientedBox.center, ob.orientedBox.extents, ob.orientedBox.rotAux, 0);
-                    }
-                }
+            // Build navmesh. Both new stages read a bordered compact heightfield whose border
+            // cells come from the neighbouring tiles' layers, so each computes the seam from the
+            // same world cells the neighbour computes it from — how the standard tiled pipeline
+            // keeps seams closed, and what the compressed layer format discards. Neither stage
+            // asked for means neither the border nor the heightfield is worth building.
+            // Watershed partitioning declines multi-layer tiles and degenerate region sets
+            // (null), which fall back to the classic monotone path.
+            RcCompactHeightfield chf = null;
+            if (m_params.watershedPartition || m_params.detailSampleDist > 0)
+            {
+                DtTileCacheBuilder.DtTileBorderGrid grid = BuildBorderGrid(tile, layer, DtTileCacheBuilder.SeamBorder);
+                chf = DtTileCacheBuilder.ToCompactHeightfield(grid, m_params);
             }
 
-            // Build navmesh
-            DtTileCacheBuilder.BuildTileCacheRegions(layer, walkableClimbVx);
-            DtTileCacheContourSet lcset = DtTileCacheBuilder.BuildTileCacheContours(m_talloc, layer, walkableClimbVx, m_params.maxSimplificationError);
+            DtTileCacheContourSet lcset = m_params.watershedPartition
+                ? DtTileCacheBuilder.BuildTileCacheContoursWatershed(m_ctx, layer, chf, m_params)
+                : null;
+            if (lcset == null)
+            {
+                DtTileCacheBuilder.BuildTileCacheRegions(layer, walkableClimbVx);
+                lcset = DtTileCacheBuilder.BuildTileCacheContours(m_talloc, layer, walkableClimbVx, m_params.maxSimplificationError);
+            }
+
             DtTileCachePolyMesh polyMesh = DtTileCacheBuilder.BuildTileCachePolyMesh(lcset, m_navmesh.GetMaxVertsPerPoly());
 
             // Early out if the mesh tile is empty.
@@ -691,6 +722,8 @@ namespace Prowl.Recast.Detour.TileCache
             option.buildBvTree = false;
             option.bmin = tile.header.bmin;
             option.bmax = tile.header.bmax;
+            if (chf != null)
+                DtTileCacheBuilder.BuildTileCacheDetailMesh(m_ctx, layer, chf, option, m_params);
             if (m_tmproc != null)
             {
                 m_tmproc.Process(option);
@@ -704,6 +737,144 @@ namespace Prowl.Recast.Detour.TileCache
             {
                 m_navmesh.AddTile(meshData, 0, 0, out var result);
             }
+        }
+
+        /// Cuts every obstacle that reaches @p refs out of that tile's layer. Kept separate from
+        /// the tile build because a tile's border reads its neighbours' layers, which must carry
+        /// the same obstacles the neighbour itself will cut when it rebuilds.
+        private void MarkObstacles(DtTileCacheLayer layer, RcVec3f bmin, long refs)
+        {
+            for (int i = 0; i < m_obstacles.Count; ++i)
+            {
+                DtTileCacheObstacle ob = m_obstacles[i];
+                if (ob.state == DtObstacleState.DT_OBSTACLE_EMPTY || ob.state == DtObstacleState.DT_OBSTACLE_REMOVING)
+                {
+                    continue;
+                }
+
+                if (!Contains(ob.touched, refs))
+                {
+                    continue;
+                }
+
+                if (ob.type == DtTileCacheObstacleType.DT_OBSTACLE_CYLINDER)
+                {
+                    DtTileCacheBuilder.MarkCylinderArea(layer, bmin, m_params.cs, m_params.ch, ob.cylinder.pos, ob.cylinder.radius, ob.cylinder.height, 0);
+                }
+                else if (ob.type == DtTileCacheObstacleType.DT_OBSTACLE_BOX)
+                {
+                    DtTileCacheBuilder.MarkBoxArea(layer, bmin, m_params.cs, m_params.ch, ob.box.bmin, ob.box.bmax, 0);
+                }
+                else if (ob.type == DtTileCacheObstacleType.DT_OBSTACLE_ORIENTED_BOX)
+                {
+                    DtTileCacheBuilder.MarkBoxArea(layer, bmin, m_params.cs, m_params.ch, ob.orientedBox.center, ob.orientedBox.extents, ob.orientedBox.rotAux, 0);
+                }
+            }
+        }
+
+        /// A neighbour's layer as a tile's border reads it: decompressed, with the obstacles that
+        /// reach it already cut out, and kept until the tiles or obstacles change. A bake meshes
+        /// every tile, and each of those reads its eight neighbours, so without this every layer
+        /// is decompressed nine times over.
+        private DtTileCacheLayer BorderLayer(long refs, DtCompressedTile tile)
+        {
+            if (m_borderLayers.TryGetValue(refs, out DtTileCacheLayer cached))
+                return cached;
+
+            DtTileCacheLayer layer = DecompressTile(tile);
+            MarkObstacles(layer, tile.header.bmin, refs);
+            // Bounded rather than grown without limit: a world of thousands of tiles would
+            // otherwise hold every one of them decompressed for the life of the cache.
+            if (m_borderLayers.Count >= MaxCachedBorderLayers)
+                m_borderLayers.Clear();
+
+            m_borderLayers[refs] = layer;
+            return layer;
+        }
+
+        /// This tile's layer widened by a border of the neighbouring tiles' cells — the data the
+        /// standard tiled pipeline gets by rasterizing past the tile edge, and the compressed
+        /// layer format discards. With it, corner heights, contours and height detail at a seam
+        /// are computed from the same world cells on both sides, and the seam closes by
+        /// construction. Border cells with no neighbour stay empty, which is exactly a map
+        /// perimeter. A neighbour stacking several vertical layers contributes, per cell, the
+        /// layer nearest this tile's own surface at the adjacent edge.
+        private DtTileCacheBuilder.DtTileBorderGrid BuildBorderGrid(DtCompressedTile tile, DtTileCacheLayer layer, int border)
+        {
+            int w = layer.header.width, h = layer.header.height;
+            var grid = new DtTileCacheBuilder.DtTileBorderGrid(w, h, border);
+
+            for (int z = 0; z < h; ++z)
+            {
+                for (int x = 0; x < w; ++x)
+                {
+                    int src = x + z * w;
+                    int dst = grid.Index(x, z);
+                    grid.heights[dst] = layer.heights[src] == DtTileCacheBuilder.NoSurface ? -1 : layer.heights[src];
+                    grid.areas[dst] = layer.areas[src];
+                }
+            }
+
+            // Our reference height beside each border cell, for choosing between a neighbour's
+            // vertical layers: the own-side edge cell nearest it.
+            int OwnRef(int gx, int gz)
+            {
+                int cx = Math.Clamp(gx, 0, w - 1);
+                int cz = Math.Clamp(gz, 0, h - 1);
+                int v = layer.heights[cx + cz * w];
+                return v == DtTileCacheBuilder.NoSurface ? -1 : v;
+            }
+
+            for (int dtx = -1; dtx <= 1; ++dtx)
+            {
+                for (int dty = -1; dty <= 1; ++dty)
+                {
+                    if (dtx == 0 && dty == 0)
+                        continue;
+
+                    m_neighbourRefs.Clear();
+                    GetTilesAt(tile.header.tx + dtx, tile.header.ty + dty, m_neighbourRefs);
+                    foreach (long r in m_neighbourRefs)
+                    {
+                        DtCompressedTile nt = GetTileByRef(r);
+                        if (nt?.header == null || nt.header.width != w || nt.header.height != h)
+                            continue;
+                        DtTileCacheLayer nl = BorderLayer(r, nt);
+                        // Layer heights are relative to their own layer's base; rebase into ours.
+                        int off = (int)Math.Round((nl.header.bmin.Y - layer.header.bmin.Y) / m_params.ch);
+
+                        // The strip of our border this neighbour covers, in our cell coordinates.
+                        int gx0 = dtx < 0 ? -border : dtx > 0 ? w : 0;
+                        int gx1 = dtx < 0 ? 0 : dtx > 0 ? w + border : w;
+                        int gz0 = dty < 0 ? -border : dty > 0 ? h : 0;
+                        int gz1 = dty < 0 ? 0 : dty > 0 ? h + border : h;
+
+                        for (int gz = gz0; gz < gz1; ++gz)
+                        {
+                            for (int gx = gx0; gx < gx1; ++gx)
+                            {
+                                int nx = gx - dtx * w;
+                                int nz = gz - dty * h;
+                                int raw = nl.heights[nx + nz * w];
+                                if (raw == DtTileCacheBuilder.NoSurface)
+                                    continue;
+
+                                int cand = raw + off;
+                                int dst = grid.Index(gx, gz);
+                                int ownRef = OwnRef(gx, gz);
+                                if (grid.heights[dst] < 0
+                                    || (ownRef >= 0 && Math.Abs(cand - ownRef) < Math.Abs(grid.heights[dst] - ownRef)))
+                                {
+                                    grid.heights[dst] = cand;
+                                    grid.areas[dst] = nl.areas[nx + nz * w];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return grid;
         }
 
         public DtTileCacheLayer DecompressTile(DtCompressedTile tile)

--- a/Recast/Recast/Detour.TileCache/DtTileCacheBuilder.cs
+++ b/Recast/Recast/Detour.TileCache/DtTileCacheBuilder.cs
@@ -639,7 +639,8 @@ namespace Prowl.Recast.Detour.TileCache
         }
 
         // TODO: move this somewhere else, once the layer meshing is done.
-        public static DtTileCacheContourSet BuildTileCacheContours(DtTileCacheAlloc alloc, DtTileCacheLayer layer, int walkableClimb, float maxError)
+        public static DtTileCacheContourSet BuildTileCacheContours(DtTileCacheAlloc alloc, DtTileCacheLayer layer,
+            int walkableClimb, float maxError)
         {
             int w = layer.header.width;
             int h = layer.header.height;
@@ -1202,7 +1203,20 @@ namespace Prowl.Recast.Detour.TileCache
                 - (verts[c] - verts[a]) * (verts[b + 2] - verts[a + 2]) < 0;
         }
 
-        public static int GetPolyMergeValue(int[] polys, int pa, int pb, int[] verts, out int ea, out int eb, int maxVertsPerPoly)
+        /// @param[in] allowCollinear  Accept unions that are only weakly convex. Off for the
+        ///                            general merge loop, on for sliver absorption, whose whole
+        ///                            purpose is to remove edges along straightened borders. A
+        ///                            corner that comes out exactly straight bothers nothing
+        ///                            downstream: Detour's point-in-polygon tests are inclusive,
+        ///                            adjacency matches exact vertex pairs, and detail hulls
+        ///                            already carry collinear vertices wherever an edge was
+        ///                            tessellated.
+        /// @param[in] maxMergedVerts  Vertex cap for the union; defaults to the per-polygon
+        ///                            budget. Sliver absorption raises it to merge past the
+        ///                            budget, on the promise of cutting the union back into two
+        ///                            polygons that fit.
+        public static int GetPolyMergeValue(int[] polys, int pa, int pb, int[] verts, out int ea, out int eb,
+            int maxVertsPerPoly, bool allowCollinear = false, int maxMergedVerts = -1)
         {
             ea = 0;
             eb = 0;
@@ -1211,7 +1225,7 @@ namespace Prowl.Recast.Detour.TileCache
             int nb = CountPolyVerts(polys, pb, maxVertsPerPoly);
 
             // If the merged polygon would be too big, do not merge.
-            if (na + nb - 2 > maxVertsPerPoly)
+            if (na + nb - 2 > (maxMergedVerts > 0 ? maxMergedVerts : maxVertsPerPoly))
                 return -1;
 
             // Check if the polygons share an edge.
@@ -1255,13 +1269,13 @@ namespace Prowl.Recast.Detour.TileCache
             va = polys[pa + (ea + na - 1) % na];
             vb = polys[pa + ea];
             vc = polys[pb + (eb + 2) % nb];
-            if (!Uleft(verts, va * 3, vb * 3, vc * 3))
+            if (!(allowCollinear ? LeftOn(verts, va * 3, vb * 3, vc * 3) : Uleft(verts, va * 3, vb * 3, vc * 3)))
                 return -1;
 
             va = polys[pb + (eb + nb - 1) % nb];
             vb = polys[pb + eb];
             vc = polys[pa + (ea + 2) % na];
-            if (!Uleft(verts, va * 3, vb * 3, vc * 3))
+            if (!(allowCollinear ? LeftOn(verts, va * 3, vb * 3, vc * 3) : Uleft(verts, va * 3, vb * 3, vc * 3)))
                 return -1;
 
             va = polys[pa + ea];
@@ -1810,9 +1824,1022 @@ namespace Prowl.Recast.Detour.TileCache
                 }
             }
 
+            // Absorb slivers. After vertex removal, whose hole re-triangulation would otherwise
+            // put back what this takes out, and before adjacency, which the merges change.
+            AbsorbSliverPolys(mesh, maxVertsPerPoly);
+
             // Calculate adjacency.
             BuildMeshAdjacency(mesh.polys, mesh.npolys, mesh.verts, mesh.nverts, lcset, maxVertsPerPoly);
 
+            return mesh;
+        }
+
+        /// XZ width in voxels under which a polygon counts as a sliver worth merging away.
+        /// Observed slivers are 0.3-0.7 voxels across; three also catches the wedge polygons
+        /// that taper to a pinched tip at a seam corner, whose forced near-vertical facets and
+        /// sampling margins otherwise leak through every later stage. Matching too eagerly
+        /// costs nothing but a chunkier polygon, since merging never changes which ground is
+        /// walkable.
+        private const int SliverWidthVoxels = 3;
+
+        /// @par
+        ///
+        /// Merges sliver polygons into a neighbour of the same area, deleting the interior edge
+        /// that pens them in; where every union overflows the vertex budget, merges past it and
+        /// cuts the union back into two polygons that fit. A strip a fraction of a voxel wide
+        /// triangulates into nothing but a near-vertical facet, since its correctly-placed corners
+        /// take the whole rise along its length across almost no width.
+        ///
+        /// Runs on the stored mesh, not one contour's scratch polygons: a sliver is frequently a
+        /// region to itself and has no partner inside its own contour.
+        ///
+        /// Only the shape of the walkable surface changes, never its extent: no vertex moves and
+        /// the outline is untouched, so tile portals still match their neighbours edge for edge.
+        private static void AbsorbSliverPolys(DtTileCachePolyMesh mesh, int maxVertsPerPoly)
+        {
+            if (maxVertsPerPoly <= 3)
+                return;
+
+            int[] ring = new int[maxVertsPerPoly * 2];
+            int[] bestRing = new int[maxVertsPerPoly * 2];
+            int[] half = new int[maxVertsPerPoly];
+
+            // Which polygons are slivers, kept rather than re-derived: a merge changes the shape
+            // of exactly one polygon and moves one other into the freed slot, so every other
+            // answer still holds.
+            bool[] isSliver = new bool[mesh.npolys];
+            for (int i = 0; i < mesh.npolys; ++i)
+                isSliver[i] = IsSliverPoly(mesh, i, maxVertsPerPoly, SliverWidthVoxels);
+
+            for (;;)
+            {
+                // Best in-budget merge over every sliver. The highest merge value is the longest
+                // shared edge, which is the interior wall most worth deleting.
+                int bestMergeVal = 0;
+                int bestPa = 0, bestPb = 0, bestEa = 0, bestEb = 0;
+
+                for (int i = 0; i < mesh.npolys; ++i)
+                {
+                    if (!isSliver[i])
+                        continue;
+
+                    for (int j = 0; j < mesh.npolys; ++j)
+                    {
+                        // Regions mean nothing to Detour, so merging across one is fine and is
+                        // the point; areas are what a query filter reads and must not blend.
+                        if (j == i || mesh.areas[j] != mesh.areas[i])
+                            continue;
+
+                        int v = GetPolyMergeValue(mesh.polys, i * maxVertsPerPoly * 2, j * maxVertsPerPoly * 2,
+                            mesh.verts, out var ea, out var eb, maxVertsPerPoly, allowCollinear: true);
+                        if (v > bestMergeVal)
+                        {
+                            bestMergeVal = v;
+                            bestPa = i;
+                            bestPb = j;
+                            bestEa = ea;
+                            bestEb = eb;
+                        }
+                    }
+                }
+
+                if (bestMergeVal > 0)
+                {
+                    // Merge into the lower slot, so the compaction below cannot move the polygon
+                    // just merged into. The per-contour merge loop gets the same invariant from
+                    // searching ordered pairs; this pass searches both directions and has to
+                    // restore it.
+                    if (bestPa > bestPb)
+                    {
+                        (bestPa, bestPb) = (bestPb, bestPa);
+                        (bestEa, bestEb) = (bestEb, bestEa);
+                    }
+
+                    MergePolys(mesh.polys, bestPa * maxVertsPerPoly * 2, bestPb * maxVertsPerPoly * 2,
+                        bestEa, bestEb, maxVertsPerPoly);
+
+                    int last = mesh.npolys - 1;
+                    if (bestPb != last)
+                    {
+                        RcArrays.Copy(mesh.polys, last * maxVertsPerPoly * 2, mesh.polys, bestPb * maxVertsPerPoly * 2,
+                            maxVertsPerPoly * 2);
+                        mesh.areas[bestPb] = mesh.areas[last];
+                        mesh.flags[bestPb] = mesh.flags[last];
+                        isSliver[bestPb] = isSliver[last];
+                    }
+
+                    isSliver[bestPa] = IsSliverPoly(mesh, bestPa, maxVertsPerPoly, SliverWidthVoxels);
+                    mesh.npolys--;
+                    continue;
+                }
+
+                // Every remaining sliver's unions overflow the vertex budget (a sliver plus a
+                // full hexagon is the common case). Merge past the budget and cut the union in
+                // two along the diagonal that leaves the narrower half widest. Both halves must
+                // clear the sliver threshold — by the same exact arithmetic the hunt above uses,
+                // or the pass would chase its own output — so every cut retires a sliver for
+                // good, which is also why this terminates. Polygon count is unchanged: two in,
+                // one union, two out.
+                double bestScore = -1;
+                int splitPa = -1, splitPb = 0, bestS = 0, bestT = 0, bestN = 0;
+
+                for (int i = 0; i < mesh.npolys; ++i)
+                {
+                    if (!isSliver[i])
+                        continue;
+
+                    for (int j = 0; j < mesh.npolys; ++j)
+                    {
+                        if (j == i || mesh.areas[j] != mesh.areas[i])
+                            continue;
+
+                        int v = GetPolyMergeValue(mesh.polys, i * maxVertsPerPoly * 2, j * maxVertsPerPoly * 2,
+                            mesh.verts, out var ea, out var eb, maxVertsPerPoly, allowCollinear: true,
+                            maxMergedVerts: maxVertsPerPoly * 2 - 2);
+                        if (v <= 0)
+                            continue;
+
+                        int n = BuildMergedRing(mesh.polys, i * maxVertsPerPoly * 2, j * maxVertsPerPoly * 2,
+                            ea, eb, maxVertsPerPoly, ring);
+                        if (FindRingSplit(ring, n, mesh.verts, maxVertsPerPoly, half, out int s, out int t, out double score)
+                            && score > bestScore)
+                        {
+                            bestScore = score;
+                            splitPa = i;
+                            splitPb = j;
+                            bestS = s;
+                            bestT = t;
+                            bestN = n;
+                            RcArrays.Copy(ring, 0, bestRing, 0, n);
+                        }
+                    }
+                }
+
+                if (splitPa < 0)
+                    break;
+
+                WriteRingRange(mesh.polys, splitPa * maxVertsPerPoly * 2, bestRing, bestS, bestT, bestN, maxVertsPerPoly);
+                WriteRingRange(mesh.polys, splitPb * maxVertsPerPoly * 2, bestRing, bestT, bestS, bestN, maxVertsPerPoly);
+                isSliver[splitPa] = IsSliverPoly(mesh, splitPa, maxVertsPerPoly, SliverWidthVoxels);
+                isSliver[splitPb] = IsSliverPoly(mesh, splitPb, maxVertsPerPoly, SliverWidthVoxels);
+            }
+        }
+
+        private static bool IsSliverPoly(DtTileCachePolyMesh mesh, int poly, int maxVertsPerPoly, int widthVoxels)
+        {
+            int p = poly * maxVertsPerPoly * 2;
+            int n = CountPolyVerts(mesh.polys, p, maxVertsPerPoly);
+            return n >= 3 && IsSliverRing(mesh.polys, p, n, mesh.verts, widthVoxels);
+        }
+
+        /// Whether a polygon ring covers a strip narrower than @p widthVoxels: twice the XZ area
+        /// over the longest edge is the width of that strip.
+        private static bool IsSliverRing(int[] polys, int p, int n, int[] verts, int widthVoxels)
+        {
+            RingSpan(polys, p, n, verts, out long area2, out long maxEdgeSq);
+            return area2 * area2 < (long)widthVoxels * widthVoxels * maxEdgeSq;
+        }
+
+        /// Twice the XZ area of a vertex ring and its longest squared edge. Integer voxel maths
+        /// like the rest of the builder, widened to long because the squared area overflows an
+        /// int on a full layer.
+        private static void RingSpan(int[] ring, int p, int n, int[] verts, out long area2, out long maxEdgeSq)
+        {
+            area2 = 0;
+            maxEdgeSq = 0;
+            for (int i = 0, j = n - 1; i < n; j = i++)
+            {
+                int a = ring[p + j] * 3;
+                int b = ring[p + i] * 3;
+                area2 += ((long)verts[a] * verts[b + 2]) - ((long)verts[b] * verts[a + 2]);
+
+                long dx = verts[b] - verts[a];
+                long dz = verts[b + 2] - verts[a + 2];
+                maxEdgeSq = Math.Max(maxEdgeSq, (dx * dx) + (dz * dz));
+            }
+
+            area2 = Math.Abs(area2);
+        }
+
+        /// The union ring of two polygons sharing edge @p ea / @p eb, laid out the way MergePolys
+        /// lays it out — first polygon's vertices from past the shared edge around, then the
+        /// second's — except into caller scratch, because here the union may exceed the
+        /// per-polygon budget. Returns the ring's vertex count.
+        private static int BuildMergedRing(int[] polys, int pa, int pb, int ea, int eb, int maxVertsPerPoly, int[] ring)
+        {
+            int na = CountPolyVerts(polys, pa, maxVertsPerPoly);
+            int nb = CountPolyVerts(polys, pb, maxVertsPerPoly);
+            int n = 0;
+            for (int i = 0; i < na - 1; ++i)
+                ring[n++] = polys[pa + (ea + 1 + i) % na];
+            for (int i = 0; i < nb - 1; ++i)
+                ring[n++] = polys[pb + (eb + 1 + i) % nb];
+            return n;
+        }
+
+        /// The diagonal cutting @p ring into the two most usable polygons: both inside the vertex
+        /// budget, neither a sliver, and the narrower of the two as wide as any cut can make it.
+        /// The ring is convex — the merge checked its two seams and every other corner came from
+        /// a convex polygon unchanged — so any diagonal lies inside it and no intersection tests
+        /// are needed. False when every cut leaves a sliver behind.
+        private static bool FindRingSplit(int[] ring, int n, int[] verts, int maxVertsPerPoly, int[] half,
+            out int s, out int t, out double score)
+        {
+            s = 0;
+            t = 0;
+            score = -1;
+            for (int a = 0; a < n - 2; ++a)
+            {
+                for (int b = a + 2; b < n; ++b)
+                {
+                    if (a == 0 && b == n - 1)
+                        continue; // consecutive around the wrap: a ring edge, not a diagonal
+
+                    if (b - a + 1 > maxVertsPerPoly || n - (b - a) + 1 > maxVertsPerPoly)
+                        continue;
+
+                    if (!TryHalf(ring, a, b, n, verts, half, out double w1)
+                        || !TryHalf(ring, b, a, n, verts, half, out double w2))
+                        continue;
+
+                    double d = Math.Min(w1, w2);
+                    if (d > score)
+                    {
+                        score = d;
+                        s = a;
+                        t = b;
+                    }
+                }
+            }
+
+            return score >= 0;
+        }
+
+        /// Measures the sub-ring from @p from to @p to inclusive, wrapping. False when the piece
+        /// is itself a sliver, judged by the same exact arithmetic the absorption pass hunts
+        /// with; the width comes back as a double only to rank cuts.
+        private static bool TryHalf(int[] ring, int from, int to, int n, int[] verts, int[] half, out double width)
+        {
+            int count = ((to - from) + n) % n + 1;
+            for (int i = 0; i < count; ++i)
+                half[i] = ring[(from + i) % n];
+
+            RingSpan(half, 0, count, verts, out long area2, out long maxEdgeSq);
+            width = maxEdgeSq > 0 ? area2 / Math.Sqrt(maxEdgeSq) : 0;
+            return area2 * area2 >= (long)SliverWidthVoxels * SliverWidthVoxels * maxEdgeSq;
+        }
+
+        /// Writes the sub-ring from @p from to @p to inclusive (wrapping) into a polygon slot's
+        /// vertex half, padding the remainder with the null index. The adjacency half is left
+        /// alone: it is computed after this pass.
+        private static void WriteRingRange(int[] polys, int p, int[] ring, int from, int to, int n, int maxVertsPerPoly)
+        {
+            int count = ((to - from) + n) % n + 1;
+            for (int k = 0; k < maxVertsPerPoly; ++k)
+                polys[p + k] = k < count ? ring[(from + k) % n] : DT_TILECACHE_NULL_IDX;
+        }
+
+        /// The height a layer cell carries where the layer has no surface. Layers are built with a
+        /// span under 255 voxels, which is what leaves this value free to mean "nothing here".
+        internal const int NoSurface = 0xFF;
+
+        /// How many cells of the neighbouring tiles' layers a tile borrows around its edge when
+        /// it meshes. The standard tiled pipeline rasterizes past the tile edge for the same
+        /// reason: with the seam's surroundings present on both sides, corner heights, contours
+        /// and height detail at the seam are computed from the same world cells by both tiles,
+        /// and the seam closes by construction. Two cells covers everything that reads across
+        /// the boundary — corner neighbourhoods and detail height patches alike.
+        public const int SeamBorder = 2;
+
+        /// A tile's layer widened by #SeamBorder cells of its neighbours' layers, heights
+        /// rebased into this tile's units. -1 marks no surface — rebased neighbour heights can
+        /// take any value, so the layer's own 0xFF sentinel is not safe here.
+        public class DtTileBorderGrid
+        {
+            public readonly int width;   // core width, without the border
+            public readonly int height;  // core height, without the border
+            public readonly int border;
+            public readonly int[] heights;
+            public readonly int[] areas;
+
+            public DtTileBorderGrid(int width, int height, int border)
+            {
+                this.width = width;
+                this.height = height;
+                this.border = border;
+                int gw = width + border * 2, gh = height + border * 2;
+                heights = new int[gw * gh];
+                areas = new int[gw * gh];
+                Array.Fill(heights, -1);
+            }
+
+            /// Index by core cell coordinates; the border lives at -border..-1 and width..width+border-1.
+            public int Index(int x, int z) => (x + border) + (z + border) * (width + border * 2);
+        }
+
+        /// @par
+        ///
+        /// Partitions and contours a tile with the standard pipeline instead of the cache's
+        /// classic monotone sweep: a watershed over a distance field for regions, and
+        /// rcBuildContours for outlines — which handles regions that enclose holes (the classic
+        /// walker traces one loop per region and silently drops the rest), takes corner heights
+        /// through span connectivity rather than any cell within climbing reach, and splits
+        /// contour edges longer than @p DtTileCacheParams.maxEdgeLen so open ground polygonizes
+        /// into compact local polygons instead of fans that reach across the tile.
+        ///
+        /// Returns null when the tile needs the classic path instead: when any interior cell
+        /// carries a portal to another vertical layer — the heightfield here holds one layer, so
+        /// the standard contourer cannot place the mandatory vertices those seams need — or when
+        /// the contourer rejects the region set outright.
+        ///
+        /// Tile seams still stitch: portal edges lie exactly on the tile boundary lines, where
+        /// simplification cannot move them, and each converted edge takes its portal direction
+        /// from the layer's own connection bits.
+        public static DtTileCacheContourSet BuildTileCacheContoursWatershed(RcContext ctx, DtTileCacheLayer layer,
+            RcCompactHeightfield chf, in DtTileCacheParams cacheParams)
+        {
+            if (HasInteriorLayerPortals(layer))
+                return null;
+
+            RcContourSet rcset;
+            try
+            {
+                RcRegions.BuildDistanceField(ctx, chf);
+                RcRegions.BuildRegions(ctx, chf, cacheParams.minRegionArea, cacheParams.mergeRegionArea);
+                rcset = RcContours.BuildContours(ctx, chf, cacheParams.maxSimplificationError,
+                    cacheParams.maxEdgeLen, RcBuildContoursFlags.RC_CONTOUR_TESS_WALL_EDGES);
+            }
+            catch (Exception e)
+            {
+                // "Multiple outlines" / "bad outline": over-aggressive simplification made a
+                // contour self-overlap. Rare, and the classic path still produces a usable tile.
+                ctx.Warn("BuildTileCacheContoursWatershed: falling back to monotone partitioning: " + e.Message);
+                return null;
+            }
+
+            var lcset = new DtTileCacheContourSet();
+            lcset.nconts = rcset.conts.Count;
+            lcset.conts = new DtTileCacheContour[lcset.nconts];
+
+            for (int i = 0; i < rcset.conts.Count; i++)
+            {
+                RcContour src = rcset.conts[i];
+                var cont = new DtTileCacheContour();
+                cont.nverts = src.nverts;
+                // Nothing downstream keys on the region id — polygons carry their contour's
+                // area, and adjacency matches vertices — so a watershed id past the byte just
+                // wraps harmlessly.
+                cont.reg = unchecked((byte)src.reg);
+                cont.area = (byte)src.area;
+                cont.verts = new int[src.nverts * 4];
+
+                for (int v = 0; v < src.nverts; v++)
+                {
+                    int n = (v + 1) % src.nverts;
+                    // Vertex coordinates come out core-relative — the standard contourer
+                    // subtracts the border itself — and their heights already agree with the
+                    // neighbouring tile's, because the border spans put the same world cells
+                    // under both tiles' corner rules.
+                    cont.verts[v * 4 + 0] = src.verts[v * 4 + 0];
+                    cont.verts[v * 4 + 1] = src.verts[v * 4 + 1];
+                    cont.verts[v * 4 + 2] = src.verts[v * 4 + 2];
+                    // The classic format keeps a segment's portal direction on its first vertex;
+                    // 0x0f is "not a portal". No 0x80 removal flags: the standard contourer
+                    // already places only the vertices it means to keep.
+                    cont.verts[v * 4 + 3] = PortalDir(layer,
+                        src.verts[v * 4 + 0], src.verts[v * 4 + 2],
+                        src.verts[n * 4 + 0], src.verts[n * 4 + 2]);
+                }
+
+                lcset.conts[i] = cont;
+            }
+
+            return lcset;
+        }
+
+        /// Whether any cell away from the tile boundary carries a portal bit — a seam to another
+        /// vertical layer of the same tile. Boundary cells' bits point at neighbouring tiles and
+        /// are expected.
+        private static bool HasInteriorLayerPortals(DtTileCacheLayer layer)
+        {
+            int w = layer.header.width, h = layer.header.height;
+            for (int z = 1; z < h - 1; ++z)
+                for (int x = 1; x < w - 1; ++x)
+                    if ((layer.cons[x + z * w] >> 4) != 0)
+                        return true;
+            return false;
+        }
+
+        /// The portal direction of one contour edge, or 0x0f for none: the edge must lie on a
+        /// tile boundary line, and a cell it runs along must actually connect onward through the
+        /// layer's portal bits — the map's perimeter sits on the same lines with nothing beyond.
+        private static int PortalDir(DtTileCacheLayer layer, int ax, int az, int bx, int bz)
+        {
+            int w = layer.header.width, h = layer.header.height;
+
+            int dir;
+            if (ax == 0 && bx == 0) dir = 0;
+            else if (az == h && bz == h) dir = 1;
+            else if (ax == w && bx == w) dir = 2;
+            else if (az == 0 && bz == 0) dir = 3;
+            else return 0x0f;
+
+            // The cells the edge runs along, one row or column inside the boundary line.
+            int lo, hi;
+            if (dir == 0 || dir == 2)
+            {
+                lo = Math.Min(az, bz);
+                hi = Math.Max(az, bz);
+            }
+            else
+            {
+                lo = Math.Min(ax, bx);
+                hi = Math.Max(ax, bx);
+            }
+
+            for (int k = lo; k < hi; ++k)
+            {
+                int x = dir == 0 ? 0 : dir == 2 ? w - 1 : k;
+                int z = dir == 3 ? 0 : dir == 1 ? h - 1 : k;
+                if (((layer.cons[x + z * w] >> 4) & (1 << dir)) != 0)
+                    return dir;
+            }
+
+            return 0x0f;
+        }
+
+        /// @par
+        ///
+        /// Gives the tile's polygons height detail, so Detour reads heights off the surface rather
+        /// than off each polygon's own corners. Without it a polygon is flat between its corners,
+        /// which is exact on a floor or a ramp and wrong by a wide margin on anything that curves,
+        /// where one polygon can cover a whole hillside.
+        ///
+        /// The layer is a per-cell height grid in the same coordinates as the polygon vertices, so
+        /// it is presented to rcBuildPolyMeshDetail as a one-span-per-cell compact heightfield.
+        /// Writes the detail mesh into @p option; leaves it untouched if the layer is level, since
+        /// the corners already describe the surface there.
+        ///
+        /// @param[in]      ctx           The build context.
+        /// @param[in]      layer         The layer the tile was contoured from.
+        /// @param[in]      chf           The layer as a compact heightfield (#ToCompactHeightfield),
+        ///                               shared with the partition stage rather than rebuilt.
+        /// @param[in,out]  option        Tile parameters carrying the polygon mesh.
+        /// @param[in]      cacheParams   The cache's parameters, for the sampling settings.
+        public static void BuildTileCacheDetailMesh(RcContext ctx, DtTileCacheLayer layer, RcCompactHeightfield chf,
+            DtNavMeshCreateParams option, in DtTileCacheParams cacheParams)
+        {
+            if (option.polyCount == 0 || cacheParams.detailSampleDist <= 0 || IsLevel(layer))
+                return;
+
+            RcPolyMesh mesh = ToPolyMesh(option);
+            mesh.maxEdgeError = cacheParams.maxSimplificationError;
+            // Polygon vertices are core-relative while the heightfield carries the seam
+            // border; the detail builder offsets its heightfield reads by this, exactly as the
+            // standard pipeline does.
+            mesh.borderSize = chf.borderSize;
+
+            // Both tiles at a seam draw the seam's one canonical polyline (#RcSeamProfileSet):
+            // polygon corners on a seam line snap to it, and the detail builder fills each
+            // seam edge with its knots instead of sampling.
+            RcSeamProfileSet seams = RcSeamProfileSet.Build(chf, cacheParams.detailSampleMaxError);
+            if (seams != null)
+                SnapSeamCorners(option, chf, seams);
+
+            // Interior samples at half the outline spacing: cache polygons are small enough that
+            // at one shared spacing most clear neither the extent bar nor the grid's edge margin,
+            // leaving their interiors to whatever their outlines span. Outline spacing stays as
+            // configured — each extra outline vertex on a barely-not-a-sliver polygon costs a
+            // steep facet.
+            RcPolyMeshDetail dmesh = RcMeshDetails.BuildPolyMeshDetail(ctx, mesh, chf,
+                cacheParams.detailSampleDist, cacheParams.detailSampleMaxError, seams,
+                cacheParams.detailSampleDist * 0.5f);
+            if (dmesh == null)
+                return;
+
+            // The detail builder lifts every vertex it emits, corner copies included, one cell
+            // height; the built tile discards those copies and reads corners from the polygon
+            // vertices instead. Align them to what the tile will render, or the passes below
+            // judge facets a step away from the ones agents and the scene view get.
+            for (int i = 0; i < dmesh.nmeshes; ++i)
+            {
+                int vb = dmesh.meshes[i * 4 + 0];
+                int npoly = CountPolyVerts(option.polys, i * option.nvp * 2, option.nvp);
+                for (int v = 0; v < npoly; ++v)
+                {
+                    int corner = option.polys[i * option.nvp * 2 + v];
+                    dmesh.verts[(vb + v) * 3 + 1] = option.bmin.Y + option.verts[corner * 3 + 1] * option.ch;
+                }
+            }
+
+            FlipDetailPleats(option, dmesh);
+
+            option.detailMeshes = dmesh.meshes;
+            option.detailVerts = dmesh.verts;
+            option.detailVertsCount = dmesh.nverts;
+            option.detailTris = dmesh.tris;
+            option.detailTriCount = dmesh.ntris;
+        }
+
+        /// Puts every polygon corner on a seam line onto the seam's canonical polyline, so both
+        /// tiles hang their surfaces from the same heights along it. Corner heights are whole
+        /// cell heights, so a corner between two knots rounds onto the polyline rather than
+        /// landing on it; the knots either side are shared and exact, and #RcSeamProfileSet's
+        /// pins hold that rounding inside the corner's own cell. Corners the profile has
+        /// nothing for — a gap, or another walkable surface's stretch — keep their contoured
+        /// height.
+        private static void SnapSeamCorners(DtNavMeshCreateParams option, RcCompactHeightfield chf, RcSeamProfileSet seams)
+        {
+            int coreW = chf.width - chf.borderSize * 2;
+            int coreH = chf.height - chf.borderSize * 2;
+            float climb = chf.walkableClimb * chf.ch;
+            for (int v = 0; v < option.vertCount; ++v)
+            {
+                int x = option.verts[v * 3 + 0];
+                int z = option.verts[v * 3 + 2];
+                if (x != 0 && x != coreW && z != 0 && z != coreH)
+                    continue;
+
+                float yWorld = option.verts[v * 3 + 1] * chf.ch;
+                if (seams.TryEval(x * chf.cs, z * chf.cs, climb, yWorld, out float sy))
+                    option.verts[v * 3 + 1] = (int)MathF.Round(sy / chf.ch);
+            }
+        }
+
+        /// A facet steeper than this is treated as a pleat worth re-triangulating: tan 50°. The
+        /// walk limit anything sensible bakes with is 45°, so real ground stays below this and
+        /// only artifacts stand above it.
+        private const double PleatTanSlope = 1.19;
+
+        /// @par
+        ///
+        /// Re-triangulates knife-pleats out of the detail mesh: triangles penned into the strip
+        /// between three nearly collinear outline vertices, whose near-zero footprint takes the
+        /// whole height change along the run and draws as a streak of wall on smooth ground.
+        /// Every vertex is already at the right height — only the connectivity is wrong — so
+        /// flipping the interior edge re-covers the same quad with two triangles that have real
+        /// footprint and real slope.
+        ///
+        /// Hull edges are never re-cut, so the surface along polygon boundaries — where
+        /// neighbours must tell the same story — is untouched, and no vertex is added, moved or
+        /// removed; only the interior diagonals change.
+        ///
+        /// A polygon whose detail vertices all sit on its boundary ring is re-cut outright to the
+        /// ring triangulation with the flattest worst facet (#RetriangulateRing), because single
+        /// flips cannot get there: around a collinear run every path to it climbs through steeper
+        /// intermediates and a greedy pass parks. Interior samples give flips room to work, and
+        /// each accepted flip strictly flattens the steeper of its pair, so the passes settle.
+        private static void FlipDetailPleats(DtNavMeshCreateParams option, RcPolyMeshDetail dmesh)
+        {
+            int maxRing = 0;
+            for (int i = 0; i < dmesh.nmeshes; ++i)
+                maxRing = Math.Max(maxRing, dmesh.meshes[i * 4 + 1]);
+            int[] ring = new int[maxRing];
+            RingDpScratch dp = null;
+
+            for (int i = 0; i < dmesh.nmeshes; ++i)
+            {
+                int vb = dmesh.meshes[i * 4 + 0];
+                int tb = dmesh.meshes[i * 4 + 2];
+                int ntris = dmesh.meshes[i * 4 + 3];
+
+                double worst = 0;
+                for (int t = 0; t < ntris; ++t)
+                    worst = Math.Max(worst, TriTanSlope(dmesh, vb, tb + t));
+                if (worst <= PleatTanSlope)
+                    continue;
+
+                int npoly = CountPolyVerts(option.polys, i * option.nvp * 2, option.nvp);
+                if (TryBuildHullRing(dmesh, i, npoly, ring, out int ringLen))
+                {
+                    dp ??= new RingDpScratch();
+                    dp.EnsureCapacity(ringLen);
+                    RetriangulateRing(dmesh, i, ring, ringLen, worst, dp);
+                    continue;
+                }
+
+                for (int pass = 0; pass < 8; ++pass)
+                {
+                    bool improved = false;
+                    for (int t = 0; t < ntris; ++t)
+                    {
+                        if (TriTanSlope(dmesh, vb, tb + t) > PleatTanSlope)
+                            improved |= TryFlipPleat(dmesh, vb, tb, ntris, t);
+                    }
+
+                    if (!improved)
+                        break;
+                }
+            }
+        }
+
+        /// Orders a polygon's detail vertices around its boundary: corners in polygon order,
+        /// each followed by the edge-tessellation vertices that lie on its outgoing edge, sorted
+        /// along it. False when any vertex sits off the boundary — an interior sample — because
+        /// then the ring alone does not describe the polygon and re-cutting it would drop real
+        /// surface data.
+        private static bool TryBuildHullRing(RcPolyMeshDetail dmesh, int poly, int npoly, int[] ring, out int ringLen)
+        {
+            int vb = dmesh.meshes[poly * 4 + 0];
+            int nverts = dmesh.meshes[poly * 4 + 1];
+            int ntris = dmesh.meshes[poly * 4 + 3];
+            ringLen = 0;
+            if (npoly < 3 || nverts < npoly || ntris != nverts - 2)
+                return false;
+
+            // Which hull edge carries each added vertex, and how far along. Edge vertices were
+            // made by lerping along the edge, so the fit is tight; anything that misses every
+            // edge is an interior sample.
+            const double tol = 0.01;
+            Span<int> onEdge = nverts - npoly <= 128 ? stackalloc int[nverts - npoly] : new int[nverts - npoly];
+            Span<double> along = nverts - npoly <= 128 ? stackalloc double[nverts - npoly] : new double[nverts - npoly];
+            for (int a = npoly; a < nverts; ++a)
+            {
+                int va = (vb + a) * 3;
+                double px = dmesh.verts[va], pz = dmesh.verts[va + 2];
+
+                int bestEdge = -1;
+                double bestDist = tol, bestT = 0;
+                for (int e = 0; e < npoly; ++e)
+                {
+                    int e0 = (vb + e) * 3;
+                    int e1 = (vb + (e + 1) % npoly) * 3;
+                    double ax = dmesh.verts[e0], az = dmesh.verts[e0 + 2];
+                    double bx = dmesh.verts[e1], bz = dmesh.verts[e1 + 2];
+                    double dx = bx - ax, dz = bz - az;
+                    double lenSq = dx * dx + dz * dz;
+                    if (lenSq < 1e-12) continue;
+                    double t = ((px - ax) * dx + (pz - az) * dz) / lenSq;
+                    if (t <= 0 || t >= 1) continue;
+                    double ox = ax + t * dx - px, oz = az + t * dz - pz;
+                    double dist = Math.Sqrt(ox * ox + oz * oz);
+                    if (dist < bestDist)
+                    {
+                        bestDist = dist;
+                        bestEdge = e;
+                        bestT = t;
+                    }
+                }
+
+                if (bestEdge < 0)
+                    return false;
+                onEdge[a - npoly] = bestEdge;
+                along[a - npoly] = bestT;
+            }
+
+            for (int e = 0; e < npoly; ++e)
+            {
+                ring[ringLen++] = e;
+                // Insertion order along the edge; counts are tiny.
+                int start = ringLen;
+                for (int a = 0; a < nverts - npoly; ++a)
+                {
+                    if (onEdge[a] != e) continue;
+                    int at = ringLen++;
+                    while (at > start && along[ring[at - 1] - npoly] > along[a])
+                    {
+                        ring[at] = ring[at - 1];
+                        at--;
+                    }
+                    ring[at] = npoly + a;
+                }
+            }
+
+            return ringLen == nverts;
+        }
+
+        /// Re-cuts a boundary ring to the triangulation with the flattest steepest facet, by
+        /// interval dynamic programming over the ring — small rings, and only polygons that
+        /// contain a pleat get here. Ring edges are all boundary and are all kept; only the
+        /// diagonals are chosen. Leaves the mesh alone unless the optimum actually beats the
+        /// triangulation it arrived with.
+        private static void RetriangulateRing(RcPolyMeshDetail dmesh, int poly, int[] ring, int n, double currentWorst,
+            RingDpScratch scratch)
+        {
+            int vb = dmesh.meshes[poly * 4 + 0];
+            int tb = dmesh.meshes[poly * 4 + 2];
+
+            double[] best = scratch.Best;
+            int[] pick = scratch.Pick;
+            int stride = scratch.Stride;
+            for (int len = 2; len < n; ++len)
+            {
+                for (int i = 0; i + len < n; ++i)
+                {
+                    int j = i + len;
+                    double b = double.MaxValue;
+                    int bk = -1;
+                    for (int k = i + 1; k < j; ++k)
+                    {
+                        double v = Math.Max(TanSlope(dmesh, vb, ring[i], ring[k], ring[j]),
+                            Math.Max(best[i * stride + k], best[k * stride + j]));
+                        if (v < b)
+                        {
+                            b = v;
+                            bk = k;
+                        }
+                    }
+
+                    best[i * stride + j] = b;
+                    pick[i * stride + j] = bk;
+                }
+            }
+
+            if (best[n - 1] >= currentWorst)
+                return;
+
+            const int hull = 0x1; // DT_DETAIL_EDGE_BOUNDARY
+            int dst = tb * 4;
+            List<int> stack = scratch.Stack;
+            stack.Clear();
+            stack.Add(0);
+            stack.Add(n - 1);
+            while (stack.Count > 0)
+            {
+                int j = stack[^1];
+                int i = stack[^2];
+                stack.RemoveRange(stack.Count - 2, 2);
+                if (j - i < 2) continue;
+                int k = pick[i * stride + j];
+
+                dmesh.tris[dst++] = ring[i];
+                dmesh.tris[dst++] = ring[k];
+                dmesh.tris[dst++] = ring[j];
+                dmesh.tris[dst++] = (k == i + 1 ? hull : 0)
+                    | (j == k + 1 ? hull << 2 : 0)
+                    | (i == 0 && j == n - 1 ? hull << 4 : 0);
+
+                stack.Add(i);
+                stack.Add(k);
+                stack.Add(k);
+                stack.Add(j);
+            }
+        }
+
+        /// Working set for #RetriangulateRing's interval DP, sized once for the largest ring in a
+        /// tile: two n×n tables in flat arrays and the walk's own stack.
+        private sealed class RingDpScratch
+        {
+            public double[] Best = [];
+            public int[] Pick = [];
+            public readonly List<int> Stack = [];
+            public int Stride;
+
+            public void EnsureCapacity(int n)
+            {
+                if (Stride < n)
+                {
+                    Stride = n;
+                    Best = new double[n * n];
+                    Pick = new int[n * n];
+                    return;
+                }
+
+                // Intervals shorter than two edges are never written but are read as the zero
+                // base case, so the rows this ring will use start clear.
+                for (int i = 0; i < n; ++i)
+                    Array.Clear(Best, i * Stride, n);
+            }
+        }
+
+        /// Tangent of one detail triangle's slope against level ground — the horizontal over the
+        /// vertical of its normal. Degenerate footprints read as vertical.
+        private static double TriTanSlope(RcPolyMeshDetail dmesh, int vb, int tri)
+        {
+            int t = tri * 4;
+            return TanSlope(dmesh, vb, dmesh.tris[t], dmesh.tris[t + 1], dmesh.tris[t + 2]);
+        }
+
+        private static double TanSlope(RcPolyMeshDetail dmesh, int vb, int ia, int ib, int ic)
+        {
+            int a = (vb + ia) * 3;
+            int b = (vb + ib) * 3;
+            int c = (vb + ic) * 3;
+
+            double ux = dmesh.verts[b] - dmesh.verts[a], uy = dmesh.verts[b + 1] - dmesh.verts[a + 1], uz = dmesh.verts[b + 2] - dmesh.verts[a + 2];
+            double wx = dmesh.verts[c] - dmesh.verts[a], wy = dmesh.verts[c + 1] - dmesh.verts[a + 1], wz = dmesh.verts[c + 2] - dmesh.verts[a + 2];
+
+            double nx = uy * wz - uz * wy;
+            double ny = uz * wx - ux * wz;
+            double nz = ux * wy - uy * wx;
+
+            double horizontal = Math.Sqrt(nx * nx + nz * nz);
+            return Math.Abs(ny) < 1e-12 ? double.PositiveInfinity : horizontal / Math.Abs(ny);
+        }
+
+        /// Twice the XZ area of a detail triangle, signed. Not DtUtils.TriArea2D: only the sign is
+        /// read here, and these accumulate in double so the near-degenerate slivers this pass
+        /// exists to judge do not decide their own winding by float rounding.
+        private static double SignedArea2XZ(RcPolyMeshDetail dmesh, int vb, int a, int b, int c)
+        {
+            int va = (vb + a) * 3, vc2 = (vb + b) * 3, vd = (vb + c) * 3;
+            return ((double)dmesh.verts[vc2] - dmesh.verts[va]) * (dmesh.verts[vd + 2] - dmesh.verts[va + 2])
+                 - ((double)dmesh.verts[vd] - dmesh.verts[va]) * (dmesh.verts[vc2 + 2] - dmesh.verts[va + 2]);
+        }
+
+        /// Flips the first edge of pleat triangle @p t whose flip helps: the edge must be
+        /// interior (a hull flag on either side pins it), shared with another of the polygon's
+        /// triangles, the enclosing quad convex — both replacement triangles keep the winding —
+        /// and the steeper of the pair must come out flatter than it went in.
+        private static bool TryFlipPleat(RcPolyMeshDetail dmesh, int vb, int tb, int ntris, int t)
+        {
+            int ta = (tb + t) * 4;
+            for (int k = 0; k < 3; ++k)
+            {
+                if (((dmesh.tris[ta + 3] >> (k * 2)) & 0x3) != 0)
+                    continue; // hull edge: the boundary with the neighbouring polygon stays as-is
+
+                int p = dmesh.tris[ta + k];
+                int q = dmesh.tris[ta + (k + 1) % 3];
+                int r = dmesh.tris[ta + (k + 2) % 3];
+
+                // The partner triangle walks the shared edge the other way.
+                for (int u = 0; u < ntris; ++u)
+                {
+                    if (u == t)
+                        continue;
+
+                    int tu = (tb + u) * 4;
+                    int m = -1;
+                    for (int e = 0; e < 3; ++e)
+                    {
+                        if (dmesh.tris[tu + e] == q && dmesh.tris[tu + (e + 1) % 3] == p)
+                        {
+                            m = e;
+                            break;
+                        }
+                    }
+
+                    if (m < 0)
+                        continue;
+                    if (((dmesh.tris[tu + 3] >> (m * 2)) & 0x3) != 0)
+                        break; // the same edge hull-flagged from the other side
+
+                    int s = dmesh.tris[tu + (m + 2) % 3];
+
+                    // Convexity of the quad p-s-q-r, as winding: both replacements must turn the
+                    // same way as the originals.
+                    double sign = SignedArea2XZ(dmesh, vb, p, q, r);
+                    double a1 = SignedArea2XZ(dmesh, vb, p, s, r);
+                    double a2 = SignedArea2XZ(dmesh, vb, s, q, r);
+                    if (sign == 0 || Math.Sign(a1) != Math.Sign(sign) || Math.Sign(a2) != Math.Sign(sign))
+                        break;
+
+                    double oldWorst = Math.Max(TriTanSlope(dmesh, vb, tb + t), TriTanSlope(dmesh, vb, tb + u));
+
+                    int fQR = (dmesh.tris[ta + 3] >> (((k + 1) % 3) * 2)) & 0x3;
+                    int fRP = (dmesh.tris[ta + 3] >> (((k + 2) % 3) * 2)) & 0x3;
+                    int fPS = (dmesh.tris[tu + 3] >> (((m + 1) % 3) * 2)) & 0x3;
+                    int fSQ = (dmesh.tris[tu + 3] >> (((m + 2) % 3) * 2)) & 0x3;
+
+                    // Both triangles verbatim, to restore if the flip does not pay.
+                    int wasA0 = dmesh.tris[ta], wasA1 = dmesh.tris[ta + 1], wasA2 = dmesh.tris[ta + 2], wasAf = dmesh.tris[ta + 3];
+                    int wasU0 = dmesh.tris[tu], wasU1 = dmesh.tris[tu + 1], wasU2 = dmesh.tris[tu + 2], wasUf = dmesh.tris[tu + 3];
+
+                    dmesh.tris[ta] = p;
+                    dmesh.tris[ta + 1] = s;
+                    dmesh.tris[ta + 2] = r;
+                    dmesh.tris[ta + 3] = fPS | (0 << 2) | (fRP << 4);
+
+                    dmesh.tris[tu] = s;
+                    dmesh.tris[tu + 1] = q;
+                    dmesh.tris[tu + 2] = r;
+                    dmesh.tris[tu + 3] = fSQ | (fQR << 2) | (0 << 4);
+
+                    if (Math.Max(TriTanSlope(dmesh, vb, tb + t), TriTanSlope(dmesh, vb, tb + u)) < oldWorst)
+                        return true;
+
+                    // No flatter than before: put both back exactly as stored, so the edge walk
+                    // above still visits every edge it has not tried yet.
+                    dmesh.tris[ta] = wasA0;
+                    dmesh.tris[ta + 1] = wasA1;
+                    dmesh.tris[ta + 2] = wasA2;
+                    dmesh.tris[ta + 3] = wasAf;
+                    dmesh.tris[tu] = wasU0;
+                    dmesh.tris[tu + 1] = wasU1;
+                    dmesh.tris[tu + 2] = wasU2;
+                    dmesh.tris[tu + 3] = wasUf;
+                    break;
+                }
+            }
+
+            return false;
+        }
+
+        /// True when every cell the layer has a surface for sits at one height, so the polygons are
+        /// already the surface and detail would restate a flat plane. Level tiles are the common
+        /// case in a built environment, and this runs on every tile build rather than once.
+        private static bool IsLevel(DtTileCacheLayer layer)
+        {
+            int height = -1;
+            for (int i = 0; i < layer.heights.Length; i++)
+            {
+                if (layer.heights[i] == NoSurface) continue;
+                if (height < 0) height = layer.heights[i];
+                else if (layer.heights[i] != height) return false;
+            }
+
+            return true;
+        }
+
+        /// The bordered tile grid as the compact heightfield the standard builders read: one
+        /// span per cell with a surface. The partition, contour and detail stages all walk it:
+        /// regions and contours check areas themselves, and the detail builder floods each
+        /// polygon's height patch across span connections, so unwalkable surface gets spans
+        /// too, and neighbours connect on the step between them — what a heightfield built
+        /// from geometry would hold, border included.
+        ///
+        /// Spans pack densely, exactly like a real compact heightfield: array-wide passes index by
+        /// span, so padded slots would leak their sentinel values into the aggregates those passes
+        /// take.
+        public static RcCompactHeightfield ToCompactHeightfield(DtTileBorderGrid grid, in DtTileCacheParams cacheParams)
+        {
+            int b = grid.border;
+            int width = grid.width + b * 2, depth = grid.height + b * 2;
+
+            int spanCount = 0;
+            for (int i = 0; i < width * depth; ++i)
+                if (grid.heights[i] >= 0)
+                    spanCount++;
+
+            RcCompactHeightfield chf = new RcCompactHeightfield();
+            chf.width = width;
+            chf.height = depth;
+            chf.borderSize = b;
+            chf.spanCount = spanCount;
+            chf.walkableHeight = (int)MathF.Ceiling(cacheParams.walkableHeight / cacheParams.ch);
+            chf.walkableClimb = (int)MathF.Floor(cacheParams.walkableClimb / cacheParams.ch);
+            chf.cs = cacheParams.cs;
+            chf.ch = cacheParams.ch;
+            chf.cells = new RcCompactCell[width * depth];
+            chf.spans = new RcCompactSpan[spanCount];
+            chf.areas = new int[spanCount];
+
+            RcCompactSpanBuilder span = RcCompactSpanBuilder.NewBuilder();
+            int cur = 0;
+            for (int z = 0; z < depth; ++z)
+            {
+                for (int x = 0; x < width; ++x)
+                {
+                    int i = x + z * width;
+                    if (grid.heights[i] < 0)
+                    {
+                        chf.cells[i] = new RcCompactCell(cur, 0);
+                        continue;
+                    }
+
+                    chf.cells[i] = new RcCompactCell(cur, 1);
+                    chf.areas[cur] = grid.areas[i];
+
+                    span.y = grid.heights[i];
+                    span.h = chf.walkableHeight;
+                    span.con = 0;
+                    // One span per cell, so the neighbour a connection points at is always span 0.
+                    for (int dir = 0; dir < 4; ++dir)
+                        RcRecast.SetCon(span, dir,
+                            Steps(grid.heights, width, depth, x, z, dir, chf.walkableClimb) ? 0 : RcRecast.RC_NOT_CONNECTED);
+                    chf.spans[cur] = new RcCompactSpan(span);
+                    cur++;
+                }
+            }
+
+            return chf;
+        }
+
+        /// Whether a cell's neighbour in one direction has a surface within climbing distance of
+        /// it, which is what a compact heightfield means by connected.
+        private static bool Steps(int[] heights, int width, int depth, int x, int z, int dir, int walkableClimb)
+        {
+            int nx = x + RcRecast.GetDirOffsetX(dir);
+            int nz = z + RcRecast.GetDirOffsetY(dir);
+            if (nx < 0 || nz < 0 || nx >= width || nz >= depth)
+                return false;
+
+            int neighbour = heights[nx + nz * width];
+            return neighbour >= 0 && Math.Abs(neighbour - heights[x + z * width]) <= walkableClimb;
+        }
+
+        /// The tile's polygons as the mesh the detail builder walks. Regions stay at
+        /// RC_MULTIPLE_REGS because the cache keeps no region ids: that sends the builder down its
+        /// seed-from-the-polygon-center path, which starts at the cell nearest a corner, walks in
+        /// to the middle and floods the height patch from there, rather than gathering heights by
+        /// a region id the cache cannot supply.
+        private static RcPolyMesh ToPolyMesh(DtNavMeshCreateParams option)
+        {
+            RcPolyMesh mesh = new RcPolyMesh();
+            mesh.verts = option.verts;
+            mesh.polys = option.polys;
+            mesh.areas = option.polyAreas;
+            mesh.flags = option.polyFlags;
+            mesh.regs = new int[option.polyCount];
+            mesh.nverts = option.vertCount;
+            mesh.npolys = option.polyCount;
+            mesh.maxpolys = option.polyCount;
+            mesh.nvp = option.nvp;
+            mesh.bmin = option.bmin;
+            mesh.bmax = option.bmax;
+            mesh.cs = option.cs;
+            mesh.ch = option.ch;
             return mesh;
         }
 

--- a/Recast/Recast/Detour.TileCache/DtTileCacheParams.cs
+++ b/Recast/Recast/Detour.TileCache/DtTileCacheParams.cs
@@ -31,6 +31,29 @@ namespace Prowl.Recast.Detour.TileCache
         public float walkableRadius;
         public float walkableClimb;
         public float maxSimplificationError;
+
+        /// Spacing of the height samples used to give each tile's polygons height detail, in world
+        /// units, and how far the detail may sit from the sampled surface before it is subdivided.
+        /// Leave detailSampleDist at 0 to build tiles without detail, in which case Detour treats
+        /// every polygon as flat between its own corners.
+        public float detailSampleDist;
+        public float detailSampleMaxError;
+
+        /// Partition tiles with a watershed over a distance field and contour them with the
+        /// standard builder — hole-aware, connectivity-based corner heights, long edges split —
+        /// instead of the cache's classic monotone sweep, whose row-band regions come out a
+        /// fraction of a voxel wide on sloped ground and whose unsplit contours polygonize open
+        /// ground into fans that reach across the tile. Tiles stacking several vertical layers
+        /// keep the classic path either way: the standard contourer cannot see the other layers.
+        public bool watershedPartition;
+
+        /// Watershed tuning, used only when @p watershedPartition is set: regions smaller than
+        /// minRegionArea cells are culled, regions smaller than mergeRegionArea cells are merged
+        /// into their neighbours, and contour edges longer than maxEdgeLen voxels are split.
+        public int minRegionArea;
+        public int mergeRegionArea;
+        public int maxEdgeLen;
+
         public int maxTiles;
         public int maxObstacles;
     }

--- a/Recast/Recast/Recast/RcMeshDetails.cs
+++ b/Recast/Recast/Recast/RcMeshDetails.cs
@@ -714,8 +714,16 @@ namespace Prowl.Recast
             float sampleDist, float sampleMaxError,
             int heightSearchRadius, RcCompactHeightfield chf,
             RcHeightPatch hp, float[] verts,
-            ref List<int> tris, ref List<int> edges, ref List<int> samples)
+            ref List<int> tris, ref List<int> edges, ref List<int> samples,
+            RcSeamProfileSet seams = null, float interiorSampleDist = 0)
         {
+            // Outline and interior vertices get their own spacing: an outline vertex is shared
+            // with the neighbouring polygon and mints a steep facet on anything near a sliver,
+            // while an interior vertex is the polygon's own and costs only itself. Defaults to
+            // the outline spacing, which is the single-spacing behaviour.
+            if (interiorSampleDist <= 0)
+                interiorSampleDist = sampleDist;
+
             const int MAX_VERTS = 127;
             const int MAX_TRIS = 255; // Max tris for delaunay is 2n-2-k (n=num verts, k=num hull verts).
             const int MAX_VERTS_PER_EDGE = 32;
@@ -748,6 +756,37 @@ namespace Prowl.Recast
                 {
                     int vj = j * 3;
                     int vi = i * 3;
+
+                    // An edge along a seam line that the line's profile claims is not
+                    // sampled: both tiles at the seam emit the profile's canonical knots
+                    // instead, so the two sides render the same polyline. Knots land where
+                    // the profile says, so the caller's later one-cell-height lift is
+                    // cancelled here. An unclaimed edge — another layer's, or across a
+                    // profile gap — tessellates normally below.
+                    if (seams != null && seams.TryGetSeam(@in[vj + 0], @in[vj + 2], @in[vi + 0], @in[vi + 2], out int seamLine))
+                    {
+                        int jPrev = ((j + nin - 1) % nin) * 3;
+                        int iNext = ((i + 1) % nin) * 3;
+                        int emitted = seams.EmitKnots(seamLine,
+                            @in[vj + 0], @in[vj + 1], @in[vj + 2],
+                            @in[vi + 0], @in[vi + 1], @in[vi + 2],
+                            chf.walkableClimb * chf.ch,
+                            seams.PinSafe(seamLine, @in[vj + 0], @in[vj + 2], @in[jPrev + 0], @in[jPrev + 2]),
+                            seams.PinSafe(seamLine, @in[vi + 0], @in[vi + 2], @in[iNext + 0], @in[iNext + 2]),
+                            -chf.ch, verts, nverts, MAX_VERTS - 1 - nverts);
+                        if (emitted >= 0)
+                        {
+                            hull[nhull++] = j;
+                            for (int k = 0; k < emitted; ++k)
+                            {
+                                hull[nhull++] = nverts;
+                                nverts++;
+                            }
+
+                            continue;
+                        }
+                    }
+
                     bool swapped = false;
                     // Make sure the segments are always handled in same order
                     // using lexological sort or else there will be seams.
@@ -861,7 +900,7 @@ namespace Prowl.Recast
             }
 
             // If the polygon minimum extent is small (sliver or small triangle), do not try to add internal points.
-            if (minExtent < sampleDist * 2)
+            if (minExtent < interiorSampleDist * 2)
             {
                 TriangulateHull(nverts, verts, nhull, hull, nin, tris);
                 SetTriFlags(tris, nhull, hull);
@@ -891,21 +930,21 @@ namespace Prowl.Recast
                     bmax = RcVec3f.Max(bmax, @in.ToVec3(i * 3));
                 }
 
-                int x0 = (int)MathF.Floor(bmin.X / sampleDist);
-                int x1 = (int)MathF.Ceiling(bmax.X / sampleDist);
-                int z0 = (int)MathF.Floor(bmin.Z / sampleDist);
-                int z1 = (int)MathF.Ceiling(bmax.Z / sampleDist);
+                int x0 = (int)MathF.Floor(bmin.X / interiorSampleDist);
+                int x1 = (int)MathF.Ceiling(bmax.X / interiorSampleDist);
+                int z0 = (int)MathF.Floor(bmin.Z / interiorSampleDist);
+                int z1 = (int)MathF.Ceiling(bmax.Z / interiorSampleDist);
                 samples.Clear();
                 for (int z = z0; z < z1; ++z)
                 {
                     for (int x = x0; x < x1; ++x)
                     {
                         RcVec3f pt = new RcVec3f();
-                        pt.X = x * sampleDist;
+                        pt.X = x * interiorSampleDist;
                         pt.Y = (bmax.Y + bmin.Y) * 0.5f;
-                        pt.Z = z * sampleDist;
+                        pt.Z = z * interiorSampleDist;
                         // Make sure the samples are not too close to the edges.
-                        if (DistToPoly(nin, @in, pt) > -sampleDist / 2)
+                        if (DistToPoly(nin, @in, pt) > -interiorSampleDist / 2)
                         {
                             continue;
                         }
@@ -943,9 +982,9 @@ namespace Prowl.Recast
                         RcVec3f pt = new RcVec3f();
                         // The sample location is jittered to get rid of some bad triangulations
                         // which are cause by symmetrical data from the grid structure.
-                        pt.X = samples[s + 0] * sampleDist + GetJitterX(i) * cs * 0.1f;
+                        pt.X = samples[s + 0] * interiorSampleDist + GetJitterX(i) * cs * 0.1f;
                         pt.Y = samples[s + 1] * chf.ch;
-                        pt.Z = samples[s + 2] * sampleDist + GetJitterY(i) * cs * 0.1f;
+                        pt.Z = samples[s + 2] * interiorSampleDist + GetJitterY(i) * cs * 0.1f;
                         
                         if (tris.Count == 0) 
                             continue;
@@ -1319,7 +1358,7 @@ namespace Prowl.Recast
         ///
         /// @see rcAllocPolyMeshDetail, rcPolyMesh, rcCompactHeightfield, rcPolyMeshDetail, rcConfig
         public static RcPolyMeshDetail BuildPolyMeshDetail(RcContext ctx, RcPolyMesh mesh, RcCompactHeightfield chf,
-            float sampleDist, float sampleMaxError)
+            float sampleDist, float sampleMaxError, RcSeamProfileSet seams = null, float interiorSampleDist = 0)
         {
             using var timer = ctx.ScopedTimer(RcTimerLabel.RC_TIMER_BUILD_POLYMESHDETAIL);
             if (mesh.nverts == 0 || mesh.npolys == 0)
@@ -1430,7 +1469,7 @@ namespace Prowl.Recast
                     sampleDist, sampleMaxError,
                     heightSearchRadius, chf, hp,
                     verts, ref tris,
-                    ref edges, ref samples);
+                    ref edges, ref samples, seams, interiorSampleDist);
 
                 // Move detail verts to world space.
                 for (int j = 0; j < nverts; ++j)

--- a/Recast/Recast/Recast/RcSeamProfiles.cs
+++ b/Recast/Recast/Recast/RcSeamProfiles.cs
@@ -1,0 +1,419 @@
+using System;
+using System.Collections.Generic;
+
+namespace Prowl.Recast
+{
+    /// <summary>
+    /// The canonical height polylines of a tile's four seam lines.
+    ///
+    /// Two tiles meeting at a seam read the same cells — a heightfield built with a seam
+    /// border hands both the same data — but each simplifies its own approximation of the
+    /// height profile along the line, and two independent approximations agree with each
+    /// other no better than each agrees with the profile. Instead of tightening budgets,
+    /// the profile is simplified once, deterministically, from the shared cells; every tile
+    /// emits exactly these knots along its seam edges, so both sides of a seam render one
+    /// polyline: watertight by construction, and no denser than the error budget demands.
+    ///
+    /// Heights are in the heightfield's local frame (span heights times cell height, no
+    /// origin, no detail-builder offset). A stretch whose cells hold surfaces further apart
+    /// than the walkable climb has no single profile; nothing is evaluated or emitted there,
+    /// and both sides skip it by the same rule.
+    /// </summary>
+    public class RcSeamProfileSet
+    {
+        private const int LineWest = 0, LineEast = 1, LineSouth = 2, LineNorth = 3;
+
+        private readonly float _cs;
+        private readonly float[] _lineCoord = new float[4];
+        // Simplified knots per line, ascending t (the coordinate along the line). Knots sit
+        // at cell-corner positions, so they land on the same grid polygon corners use.
+        private readonly float[][] _knotT = new float[4][];
+        private readonly float[][] _knotY = new float[4][];
+        // True when the stretch between knot k and knot k + 1 crosses corners with no single
+        // surface.
+        private readonly bool[][] _gapAfter = new bool[4][];
+
+        private readonly float _ch;
+
+        // Build scratch, reused across the set's four lines and across tiles.
+        private float[] _raw;
+        private bool[] _valid;
+        private readonly List<float> _knotScratchT = new List<float>();
+        private readonly List<float> _knotScratchY = new List<float>();
+        private readonly List<bool> _gapScratch = new List<bool>();
+        private readonly List<int> _keepScratch = new List<int>();
+        private readonly List<int> _workScratch = new List<int>();
+
+        private RcSeamProfileSet(float cs, float ch)
+        {
+            _cs = cs;
+            _ch = ch;
+        }
+
+
+        /// Builds the four profiles from a heightfield carrying a seam border. The border is
+        /// what makes the result identical on both sides of every seam: each line's corners
+        /// read the same world cells no matter which tile is asking. Returns null without a
+        /// border, since then the tiles have nothing shared to agree on.
+        public static RcSeamProfileSet Build(RcCompactHeightfield chf, float maxError)
+        {
+            if (chf.borderSize <= 0)
+                return null;
+
+            int b = chf.borderSize;
+            int coreW = chf.width - b * 2;
+            int coreH = chf.height - b * 2;
+            if (coreW <= 0 || coreH <= 0)
+                return null;
+
+            RcSeamProfileSet set = new RcSeamProfileSet(chf.cs, chf.ch);
+            set._lineCoord[LineWest] = 0;
+            set._lineCoord[LineEast] = coreW * chf.cs;
+            set._lineCoord[LineSouth] = 0;
+            set._lineCoord[LineNorth] = coreH * chf.cs;
+            set.BuildLine(chf, LineWest, b, b, 0, 1, coreH, maxError);
+            set.BuildLine(chf, LineEast, b + coreW, b, 0, 1, coreH, maxError);
+            set.BuildLine(chf, LineSouth, b, b, 1, 0, coreW, maxError);
+            set.BuildLine(chf, LineNorth, b, b + coreH, 1, 0, coreW, maxError);
+            return set;
+        }
+
+        /// Whether the edge from a to b lies along one of the seam lines. Positions are the
+        /// heightfield's local floats, so seam vertices sit exactly on the line up to float
+        /// rounding.
+        public bool TryGetSeam(float ax, float az, float bx, float bz, out int line)
+        {
+            float eps = _cs * 0.01f;
+            for (line = LineWest; line <= LineNorth; ++line)
+            {
+                float c = _lineCoord[line];
+                bool onLine = line <= LineEast
+                    ? MathF.Abs(ax - c) < eps && MathF.Abs(bx - c) < eps
+                    : MathF.Abs(az - c) < eps && MathF.Abs(bz - c) < eps;
+                if (onLine)
+                    return true;
+            }
+
+            line = -1;
+            return false;
+        }
+
+        /// Whether a pin next to the corner at (cx, cz) is safe to emit, judged by the polygon's
+        /// other hull edge there, towards (nx, nz). Under ~20° off the seam the polygon tapers to
+        /// a near-degenerate tip, where a vertex one cell from the corner forces a steep sliver
+        /// facet no triangulation avoids.
+        public bool PinSafe(int line, float cx, float cz, float nx, float nz)
+        {
+            float along = line <= LineEast ? nz - cz : nx - cx;
+            float off = line <= LineEast ? nx - cx : nz - cz;
+            return MathF.Abs(off) > MathF.Abs(along) * 0.364f;
+        }
+
+        /// Writes the knots the stretch from a to b covers into @p outVerts, ordered from a
+        /// towards b, and returns how many — or -1 when the edge is not this profile's to fill
+        /// and the caller should tessellate it itself. @p yOffset pre-compensates an offset the
+        /// caller applies to every vertex later. Knots coinciding with an endpoint are skipped;
+        /// the polygon corner is already there.
+        public int EmitKnots(int line, float ax, float ay, float az, float bx, float by, float bz,
+            float climb, bool pinNearA, bool pinNearB, float yOffset, float[] outVerts, int startVert, int maxKnots)
+        {
+            float[] kt = _knotT[line];
+            float[] ky = _knotY[line];
+            if (kt == null || kt.Length == 0)
+                return -1;
+
+            bool alongZ = line <= LineEast;
+            float ta = alongZ ? az : ax;
+            float tb = alongZ ? bz : bx;
+            bool aOnProfile = TryEvalLine(line, ta, out float pa) && MathF.Abs(pa - ay) <= climb;
+            bool bOnProfile = TryEvalLine(line, tb, out float pb) && MathF.Abs(pb - by) <= climb;
+
+            // One endpoint on the profile is enough to claim the edge. Requiring both hands
+            // the whole edge back to ordinary sampling whenever one end reaches past the
+            // profiled stretch or onto another layer — and the tile across the seam, whose
+            // edges end elsewhere, keeps drawing the profile over the part they share, which
+            // is a disagreement over the whole overlap rather than near the one bad end.
+            if (!aOnProfile && !bOnProfile)
+                return -1;
+
+            if (maxKnots <= 0)
+                return 0;
+
+            float tMin = Math.Min(ta, tb), tMax = Math.Max(ta, tb);
+            float eps = _cs * 0.01f;
+
+            // The profile's knots inside the stretch...
+            int lo = 0;
+            while (lo < kt.Length && kt[lo] <= tMin + eps)
+                lo++;
+            int hi = kt.Length - 1;
+            while (hi >= 0 && kt[hi] >= tMax - eps)
+                hi--;
+
+            // ...plus a pin one cell inside each endpoint, holding a corner's rounding bend
+            // inside its own cell instead of letting it ramp to the nearest knot as a wedge the
+            // other side does not draw. A corner already on the profile has no bend to hold, and
+            // pins go in pairs: every hull vertex must be used, so a lone one on a thin wedge
+            // polygon pushes its best triangulation into a steep needle at the far end.
+            bool ascending = ta <= tb;
+            float exact = _ch * 0.05f;
+            bool pins = pinNearA && pinNearB && aOnProfile && bOnProfile
+                && (MathF.Abs(pa - ay) > exact || MathF.Abs(pb - by) > exact);
+
+            // Knots belong to the surface this edge is on. Where an end sits off the profile
+            // the edge is leaving it, so only knots within a climb of what the edge itself
+            // spans are its to draw.
+            float loY = MathF.Min(ay, by) - climb, hiY = MathF.Max(ay, by) + climb;
+            float pinLoT = tMin + _cs, pinHiT = tMax - _cs;
+            float pinLoY = 0, pinHiY = 0;
+            bool wantPinLo = pins
+                && pinLoT < tMax - eps
+                && (lo > hi || MathF.Abs(kt[lo] - pinLoT) > _cs * 0.5f)
+                && TryEvalLine(line, pinLoT, out pinLoY);
+            bool wantPinHi = pins
+                && pinHiT > tMin + eps
+                && MathF.Abs(pinHiT - pinLoT) > _cs * 0.5f
+                && (lo > hi || MathF.Abs(kt[hi] - pinHiT) > _cs * 0.5f)
+                && TryEvalLine(line, pinHiT, out pinHiY);
+
+            int total = (hi - lo + 1) + (wantPinLo ? 1 : 0) + (wantPinHi ? 1 : 0);
+            Span<float> candT = total <= 64 ? stackalloc float[Math.Max(total, 1)] : new float[total];
+            Span<float> candY = total <= 64 ? stackalloc float[Math.Max(total, 1)] : new float[total];
+            int n = 0;
+            if (wantPinLo)
+            {
+                candT[n] = pinLoT;
+                candY[n++] = pinLoY;
+            }
+
+            for (int k = lo; k <= hi; ++k)
+            {
+                if (ky[k] < loY || ky[k] > hiY)
+                    continue;
+
+                candT[n] = kt[k];
+                candY[n++] = ky[k];
+            }
+
+            if (wantPinHi)
+            {
+                candT[n] = pinHiT;
+                candY[n++] = pinHiY;
+            }
+
+            int emitted = 0;
+            for (int k = 0; k < n && emitted < maxKnots; ++k)
+            {
+                int c = ascending ? k : n - 1 - k;
+                int pos = (startVert + emitted) * 3;
+                outVerts[pos + 0] = alongZ ? _lineCoord[line] : candT[c];
+                outVerts[pos + 1] = candY[c] + yOffset;
+                outVerts[pos + 2] = alongZ ? candT[c] : _lineCoord[line];
+                emitted++;
+            }
+
+            return emitted;
+        }
+
+        /// Evaluates the polyline at a position on a seam line, or reports there is nothing
+        /// to agree on there: off every line, outside the profiled stretch, across a gap, or
+        /// further than @p climb from @p yNear, the height the caller already has — the same
+        /// two-surfaces guard #EmitKnots applies.
+        public bool TryEval(float x, float z, float climb, float yNear, out float y)
+        {
+            y = 0;
+            float eps = _cs * 0.01f;
+            for (int line = LineWest; line <= LineNorth; ++line)
+            {
+                float c = _lineCoord[line];
+                bool onLine = line <= LineEast ? MathF.Abs(x - c) < eps : MathF.Abs(z - c) < eps;
+                if (!onLine)
+                    continue;
+
+                float t = line <= LineEast ? z : x;
+                if (TryEvalLine(line, t, out float ly) && MathF.Abs(ly - yNear) <= climb)
+                {
+                    y = ly;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool TryEvalLine(int line, float t, out float y)
+        {
+            y = 0;
+            float[] kt = _knotT[line];
+            float[] ky = _knotY[line];
+            if (kt == null || kt.Length == 0)
+                return false;
+
+            float eps = _cs * 0.01f;
+            if (t < kt[0] - eps || t > kt[^1] + eps)
+                return false;
+
+            int lo = 0, hi = kt.Length - 1;
+            while (lo + 1 < hi)
+            {
+                int mid = (lo + hi) / 2;
+                if (kt[mid] <= t)
+                    lo = mid;
+                else
+                    hi = mid;
+            }
+
+            if (MathF.Abs(t - kt[lo]) < eps)
+            {
+                y = ky[lo];
+                return true;
+            }
+
+            if (MathF.Abs(t - kt[hi]) < eps)
+            {
+                y = ky[hi];
+                return true;
+            }
+
+            if (_gapAfter[line][lo])
+                return false;
+
+            float u = (t - kt[lo]) / (kt[hi] - kt[lo]);
+            y = ky[lo] + (ky[hi] - ky[lo]) * u;
+            return true;
+        }
+
+        /// Builds one line's polyline: the raw profile at every cell corner along the line, then
+        /// each contiguous valid run simplified on its own so nothing interpolates across a break.
+        private void BuildLine(RcCompactHeightfield chf, int line, int sx, int sz, int dx, int dz, int len,
+            float maxError)
+        {
+            // Scratch shared by all four lines of all tiles built through this set.
+            if (_raw == null || _raw.Length < len + 1)
+            {
+                _raw = new float[len + 1];
+                _valid = new bool[len + 1];
+            }
+
+            float[] raw = _raw;
+            bool[] valid = _valid;
+            for (int k = 0; k <= len; ++k)
+            {
+                int cx = sx + dx * k;
+                int cz = sz + dz * k;
+                int lowest = int.MaxValue, highest = int.MinValue, n = 0;
+                for (int oz = -1; oz <= 0; ++oz)
+                {
+                    for (int ox = -1; ox <= 0; ++ox)
+                    {
+                        int x = cx + ox, z = cz + oz;
+                        if (x < 0 || z < 0 || x >= chf.width || z >= chf.height)
+                            continue;
+
+                        ref RcCompactCell cell = ref chf.cells[x + z * chf.width];
+                        for (int si = cell.index, end = cell.index + cell.count; si < end; ++si)
+                        {
+                            int sy = chf.spans[si].y;
+                            lowest = Math.Min(lowest, sy);
+                            highest = Math.Max(highest, sy);
+                            n++;
+                        }
+                    }
+                }
+
+                // Steep walkable ground spreads nearly a step per cell, so one surface can span
+                // twice the climb across a corner's cells; separate layers stand much further.
+                valid[k] = n > 0 && highest - lowest <= chf.walkableClimb * 2;
+                // The highest touching span: it is already on the integer height grid corners are
+                // stored on, so a corner meeting a knot equals it rather than rounding off it,
+                // and it biases the seam upward like the detail builder's one-cell lift biases
+                // interiors. An average sits below both and drags seam triangles under the ground.
+                raw[k] = n > 0 ? highest * chf.ch : 0;
+            }
+
+            List<float> knotT = _knotScratchT;
+            List<float> knotY = _knotScratchY;
+            List<bool> gapAfter = _gapScratch;
+            List<int> keep = _keepScratch;
+            knotT.Clear();
+            knotY.Clear();
+            gapAfter.Clear();
+            float budget = MathF.Max(maxError, chf.ch * 0.5f);
+            int runStart = -1;
+            for (int k = 0; k <= len + 1; ++k)
+            {
+                bool v = k <= len && valid[k];
+                if (v && runStart < 0)
+                {
+                    runStart = k;
+                }
+                else if (!v && runStart >= 0)
+                {
+                    if (gapAfter.Count > 0)
+                        gapAfter[^1] = true;
+
+                    keep.Clear();
+                    SimplifyRun(raw, runStart, k - 1, budget, keep);
+                    keep.Sort();
+                    foreach (int idx in keep)
+                    {
+                        knotT.Add(idx * _cs);
+                        knotY.Add(raw[idx]);
+                        gapAfter.Add(false);
+                    }
+
+                    runStart = -1;
+                }
+            }
+
+            _knotT[line] = knotT.ToArray();
+            _knotY[line] = knotY.ToArray();
+            _gapAfter[line] = gapAfter.ToArray();
+        }
+
+        /// Douglas-Peucker on the run's vertical deviation: a knot is kept where the chord
+        /// misses the raw profile by more than the budget. Run endpoints are always kept.
+        private void SimplifyRun(float[] raw, int a, int b, float maxError, List<int> keep)
+        {
+            keep.Add(a);
+            if (b <= a)
+                return;
+
+            keep.Add(b);
+            List<int> work = _workScratch;
+            work.Clear();
+            work.Add(a);
+            work.Add(b);
+            while (work.Count > 0)
+            {
+                int hi = work[^1];
+                int lo = work[^2];
+                work.RemoveRange(work.Count - 2, 2);
+                if (hi - lo < 2)
+                    continue;
+
+                float worst = 0;
+                int worstAt = -1;
+                for (int m = lo + 1; m < hi; ++m)
+                {
+                    float chord = raw[lo] + (raw[hi] - raw[lo]) * (m - lo) / (float)(hi - lo);
+                    float dev = MathF.Abs(raw[m] - chord);
+                    if (dev > worst)
+                    {
+                        worst = dev;
+                        worstAt = m;
+                    }
+                }
+
+                if (worstAt >= 0 && worst > maxError)
+                {
+                    keep.Add(worstAt);
+                    work.Add(lo);
+                    work.Add(worstAt);
+                    work.Add(worstAt);
+                    work.Add(hi);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Changes to Prowl.Recast to help close up tile seams that were uncovered while testing NavMesh with terrains:

<img width="1875" height="818" alt="Screenshot 2026-08-11 091622" src="https://github.com/user-attachments/assets/0dd0425c-b603-4987-aadf-236ee7f22331" />
<img width="1238" height="746" alt="Screenshot 2026-08-11 103238" src="https://github.com/user-attachments/assets/bbaf9679-f51d-438f-a519-2c53abb188f6" />

Tile-cache meshing derived each tile's seam from that tile's cells alone, so the two sides of a boundary described the same ground differently.

Tiles are now meshed through a bordered compact heightfield: BuildBorderGrid reconstructs the border from the neighbouring tiles' layers (rebased across differing layer base elevations), which is the data the standard tiled pipeline gets by rasterizing past the tile edge and the compressed layer format discards. Contours and height detail read it through the standard borderSize machinery.

On top of that, RcSeamProfiles (new) simplifies each seam line's height profile once from the shared cells, and both tiles emit exactly those knots — so a seam is watertight by construction and no denser than the error budget requires.

Additionally, to help clean up the navmesh in general:

1. Watershed partitioning with standard contouring for tile-cache tiles, declining multi-layer tiles back to the classic monotone path
2. Sliver absorption (merge, or merge-then-split when the union overflows the vertex budget) and knife-pleat re-triangulation, including an optimal min-max-slope ring DP
3. BuildPolyDetail/BuildPolyMeshDetail take an optional interiorSampleDist, so interiors can be sampled finer than outlines.
4. Obstacles are cut out of neighbour layers when read as border data, and the touched-tile query is widened by the border so a tile the obstacle reaches only through its border still rebuilds
5. Decompressed neighbour layers are cached per tile ref (bounded, invalidated on tile and obstacle changes) instead of being decompressed nine times per bake.
