### PR TITLE
[Quill] Clamp brush texture sampling to an opt-in UV window to stop atlas bleed from the AA fringe

### DIFF
--- a/Quill/Quill/Canvas.cs
+++ b/Quill/Quill/Canvas.cs
@@ -151,6 +151,9 @@ namespace Prowl.Quill
         public void GetTextureTransform(float framebufferScale, out Float4 transform, out Float2 translation)
             => ToAffine(in textureInverse, framebufferScale, out transform, out translation);
 
+        /// <summary>UV-space sampling bounds for the brush texture, (uMin, vMin, uMax, vMax). uMax &lt;= uMin means unclamped.</summary>
+        public Float4 TextureClamp => Brush.TextureClamp;
+
         /// <summary>
         /// Packs a Transform2D as (A, C, B, D) plus (E, F), so the shader evaluates it as two dot
         /// products and an add. Dividing the linear part by the framebuffer scale folds in the
@@ -314,6 +317,18 @@ namespace Prowl.Quill
         public Transform2D TextureTransform;
 
         /// <summary>
+        /// UV-space bounds the brush texture may be sampled within, as (uMin, vMin, uMax, vMax).
+        /// A sub-rect draw sets this to its own UV window so the AA fringe - which extends half a physical
+        /// pixel past the nominal rect and samples by fragment position - cannot read the neighbouring
+        /// region of an atlas.
+        ///
+        /// uMax &lt;= uMin means UNCLAMPED, so a default-constructed Brush is unclamped and tiling brushes
+        /// are unaffected. Deliberately not a (0,0,1,1) default: that would break Repeat wrapping, and it
+        /// would depend on every construction site remembering to set it.
+        /// </summary>
+        public Float4 TextureClamp;
+
+        /// <summary>
         /// The type of brush (None, Linear, Radial, or Box gradient).
         /// </summary>
         public BrushType Type;
@@ -392,6 +407,7 @@ namespace Prowl.Quill
                 && BackdropBlur == other.BackdropBlur
                 && DrawCall.SameTransform(in Transform, in other.Transform)
                 && DrawCall.SameTransform(in TextureTransform, in other.TextureTransform)
+                && TextureClamp.Equals(other.TextureClamp)
                 && (Shader == null || SameUniforms(Uniforms, other.Uniforms));
         }
 
@@ -418,6 +434,7 @@ namespace Prowl.Quill
                 hash = hash * 31 + Transform.GetHashCode();
                 hash = hash * 31 + (Texture?.GetHashCode() ?? 0);
                 hash = hash * 31 + TextureTransform.GetHashCode();
+                hash = hash * 31 + TextureClamp.GetHashCode();
                 if (Shader != null)
                 {
                     hash = hash * 31 + Shader.GetHashCode();
@@ -479,6 +496,7 @@ namespace Prowl.Quill
             brush = new Brush();
             brush.Transform = Transform2D.Identity;
             brush.TextureTransform = Transform2D.Identity;
+            brush.TextureClamp = default;   // (0,0,0,0) = unclamped
             brush.Texture = null;
             brush.Shader = null;
             brush.Uniforms = null;
@@ -866,6 +884,42 @@ namespace Prowl.Quill
         }
 
         /// <summary>
+        /// Bounds brush texture sampling to a UV window. Pass the same window the texture transform maps onto
+        /// the destination rect, and the AA fringe samples the window's own edge texels instead of whatever
+        /// lies beyond it - the result ClampToEdge gives at a real texture border, but at a sub-rect border.
+        /// Call after <see cref="SetBrushTexture"/>: the stored window is inset by half a texel, which needs
+        /// the texture's size.
+        /// </summary>
+        /// <param name="uMin">Left edge in UV space. Pass uMax &lt;= uMin to disable.</param>
+        public void SetBrushTextureClamp(float uMin, float vMin, float uMax, float vMax)
+        {
+            _state.brush.TextureClamp = InsetClampHalfTexel(_state.brush.Texture, uMin, vMin, uMax, vMax);
+            InvalidateDrawState();
+        }
+
+        /// <summary>
+        /// Insets a clamp window by half a texel. Clamping to the raw window still bleeds: the window
+        /// boundary is the shared texel edge with the neighbouring atlas region, where a bilinear tap
+        /// blends 50/50 with the neighbour and a nearest tap floors into it. Half a texel in, both
+        /// filters resolve to the window's own edge texel. Windows narrower than a texel collapse to
+        /// their centre instead of inverting.
+        /// </summary>
+        private Float4 InsetClampHalfTexel(object? texture, float uMin, float vMin, float uMax, float vMax)
+        {
+            if (texture == null || uMax <= uMin || vMax <= vMin)
+                return new Float4(uMin, vMin, uMax, vMax);
+
+            var size = _renderer.GetTextureSize(texture);
+            float hx = size.X > 0 ? 0.5f / size.X : 0f;
+            float hy = size.Y > 0 ? 0.5f / size.Y : 0f;
+            float cx = (uMin + uMax) * 0.5f;
+            float cy = (vMin + vMax) * 0.5f;
+            return new Float4(
+                Maths.Min(uMin + hx, cx), Maths.Min(vMin + hy, cy),
+                Maths.Max(uMax - hx, cx), Maths.Max(vMax - hy, cy));
+        }
+
+        /// <summary>
         /// Clears the brush texture, reverting to solid color or gradient rendering.
         /// </summary>
         public void ClearBrushTexture()
@@ -873,6 +927,7 @@ namespace Prowl.Quill
             _state.brush.Type = BrushType.None;
             _state.brush.Texture = null;
             _state.brush.TextureTransform = Transform2D.Identity;
+            _state.brush.TextureClamp = default;
             InvalidateDrawState();
         }
 
@@ -2681,6 +2736,7 @@ namespace Prowl.Quill
             // Configure brush to draw the texture mapped to this rectangle
             _state.brush.Texture = texture;
             _state.brush.TextureTransform = _state.transform * Transform2D.CreateTranslation(x, y) * Transform2D.CreateScale(width, height);
+            _state.brush.TextureClamp = InsetClampHalfTexel(texture, 0, 0, 1, 1);  // whole texture; keeps the AA fringe from wrapping on Repeat samplers
             _state.brush.Type = BrushType.None;
             _state.brush.Shader = null;
             _state.brush.Uniforms = null;
@@ -2708,6 +2764,7 @@ namespace Prowl.Quill
             var savedBrush = _state.brush;
             _state.brush.Texture = texture;
             _state.brush.TextureTransform = _state.transform * Transform2D.CreateTranslation(x, y) * Transform2D.CreateScale(width, height);
+            _state.brush.TextureClamp = InsetClampHalfTexel(texture, 0, 0, 1, 1);
             _state.brush.Type = BrushType.None;
             _state.brush.Shader = null;
             _state.brush.Uniforms = null;

--- a/Quill/Quill/Shaders/Canvas.slang
+++ b/Quill/Quill/Shaders/Canvas.slang
@@ -41,6 +41,7 @@ uniform float2 brushParams2;
 
 uniform float4 textureTransform;
 uniform float2 textureTranslation;
+uniform float4 textureClamp;    // uMin, vMin, uMax, vMax; uMax <= uMin = unclamped
 
 // 1 / font atlas size, so the text distance-field screen range is correct at any zoom.
 uniform float2 atlasTexelSize;
@@ -161,7 +162,13 @@ float4 Fragment(VertexOutput input) : SV_Target
     // fragTexCoord.x (1 = solid core, 0 = outer fringe edge).
     float edgeAlpha = clamp(input.fragTexCoord.x, 0.0, 1.0);
 
-    float4 fill = color * texture0.Sample(applyTransform(textureTransform, textureTranslation, input.fragPos));
+    // The AA fringe extends half a physical pixel past the nominal rect and this samples by fragPos,
+    // so without the clamp a sub-rect draw reads whatever is next to it in the atlas.
+    float2 texUV = applyTransform(textureTransform, textureTranslation, input.fragPos);
+    if (textureClamp.z > textureClamp.x)
+        texUV = clamp(texUV, textureClamp.xy, textureClamp.zw);
+
+    float4 fill = color * texture0.Sample(texUV);
 
     // Backdrop blur: composite the fill over the blurred framebuffer behind the shape.
     if (backdropBlurAmount > 0.0)


### PR DESCRIPTION
As mentioned in Discord, there is an issue with Paper using the SetTextureBrush to render a part of a spritesheet that causes the AA to bleed over some pixels, regardless of filtering on the sprite / clamping. Tested locally and can verify it fixes the issue, but the logic itself was largely handled by Claude because this is out of my knowledge space.

## Problem

Textured shape draws bleed neighbouring atlas content along their edges whenever the brush maps a
sub-rect (UV window) of a texture onto a shape:

- `RectFilled` (and shape AA in general) emits its AA fringe half a physical pixel outside the
  nominal rect (`Canvas.cs`, outer ring at `x - hp` / `x + width + hp`). The overshoot itself is
  correct: the coverage ramp is centred on the edge, so a pixel centred on the boundary gets ~0.5
  coverage and abutting shapes join without seams.
- The canvas shader samples the brush texture by fragment position and applies coverage *after* the
  sample (`Canvas.slang`: `float4 fill = color * texture0.Sample(applyTransform(..., input.fragPos))`).
- Fringe fragments therefore map to UVs outside the sprite's window — into the next atlas cell. The
  sampler can't help: ClampToEdge acts at the texture border, not at `u1`.
- `DrawImage` has the same overshoot, but its window is `[0,1]`, so ClampToEdge happens to hide it —
  and on Repeat samplers the fringe wraps and shows the opposite edge instead.

A transparent gutter in the atlas is not a substitute fix: the fringe is half a *screen* pixel,
which spans more than one texel whenever a sprite draws below native size.

## Fix

An opt-in UV clamp window on the brush, applied in the shader before the sample:

- `Brush.TextureClamp` — `(uMin, vMin, uMax, vMax)`, where `uMax <= uMin` means unclamped. The
  default is unclamped, so existing draws and tiling brushes are untouched. Deliberately not a
  `(0,0,1,1)` default: that would break Repeat wrapping and depend on every construction site
  remembering to set it.
- `Canvas.SetBrushTextureClamp(uMin, vMin, uMax, vMax)` stores the window **inset half a texel**
  toward its centre. The inset is load-bearing: the window boundary is the texel edge shared with
  the neighbouring cell, where bilinear blends 50/50 with the neighbour and nearest floors into it —
  clamping to the raw window still bleeds. Half a texel in, both filters resolve to the window's own
  edge texel. The inset needs the texture size, so call this after `SetBrushTexture`. Windows
  narrower than a texel collapse to their centre rather than inverting.
- `Canvas.slang` clamps the transformed UV to the window before sampling when a window is active —
  the behaviour ClampToEdge gives at a real texture border, produced at a sub-rect border.
- `TextureClamp` participates in `Brush.Matches`/`ComputeHash`, so adjacent sub-rect draws from one
  atlas can't merge into a single batch sharing the wrong clamp.
- `DrawImage` now self-clamps to (an inset) `[0,1]` — it knows its own window — which fixes the
  Repeat-sampler fringe wrap with no API change.

Why opt-in rather than automatic: the brush transform is a mapping, not an extent — nothing in
brush state says the paint ends at `u1`, and for tiling brushes it deliberately doesn't. Deriving
the window per-draw from the shape's bounds is only correct while the brush is axis-aligned with
the shape, and would silently bleed again under rotation. (This is the same trade-off Skia exposes
as `SrcRectConstraint` on `drawImageRect`.)

Notes: no `ICanvasRenderer` change — the inset uses the existing `GetTextureSize`. Renderers opt in
by uploading `DrawCall.TextureClamp` as the `textureClamp` uniform; one that doesn't keeps exactly
the current behaviour (zero = unclamped). Backend shaders regenerate from `Canvas.slang` via the
existing ShaderGen step.