### PR TITLE
Recast adjustments to tile building and obstacles

### DIFF
--- a/Recast/Recast/Core/RcContext.cs
+++ b/Recast/Recast/Core/RcContext.cs
@@ -41,9 +41,7 @@ namespace Prowl.Recast.Core
     public class RcContext
     {
         /// Where Warn and Log go when a host sets one. Static because a build owns a context per
-        /// thread, so there is no single instance for a host to configure. Unset, messages keep going
-        /// to the console, which is what running the tests from a terminal expects. A sink must not
-        /// throw; one that does is swallowed rather than failing the build it was logging about.
+        /// thread, so there is no single instance to configure; unset, messages go to the console.
         public static Action<RcLogCategory, string> Sink;
 
         private readonly ThreadLocal<Dictionary<string, RcAtomicLong>> _timerStart;

--- a/Recast/Recast/Core/RcContext.cs
+++ b/Recast/Recast/Core/RcContext.cs
@@ -40,6 +40,12 @@ namespace Prowl.Recast.Core
     /// @ingroup recast
     public class RcContext
     {
+        /// Where Warn and Log go when a host sets one. Static because a build owns a context per
+        /// thread, so there is no single instance for a host to configure. Unset, messages keep going
+        /// to the console, which is what running the tests from a terminal expects. A sink must not
+        /// throw; one that does is swallowed rather than failing the build it was logging about.
+        public static Action<RcLogCategory, string> Sink;
+
         private readonly ThreadLocal<Dictionary<string, RcAtomicLong>> _timerStart;
         private readonly ConcurrentDictionary<string, RcAtomicLong> _timerAccum;
 
@@ -67,13 +73,25 @@ namespace Prowl.Recast.Core
                 .AddAndGet(RcFrequency.Ticks - _timerStart.Value?[label.Name].Read() ?? 0);
         }
 
-        public void Warn(string message)
-        {
-            Console.WriteLine(message);
-        }
+        public void Warn(string message) => Log(RcLogCategory.RC_LOG_WARNING, message);
 
         public void Log(RcLogCategory logLevel, string message)
         {
+            Action<RcLogCategory, string> sink = Sink;
+            if (sink != null)
+            {
+                try
+                {
+                    sink(logLevel, message);
+                }
+                catch (Exception)
+                {
+                    // A logger cannot be allowed to abort a tile build.
+                }
+
+                return;
+            }
+
             Console.WriteLine(message);
         }
 

--- a/Recast/Recast/Detour.Crowd/DtCrowd.cs
+++ b/Recast/Recast/Detour.Crowd/DtCrowd.cs
@@ -627,6 +627,9 @@ namespace Prowl.Recast.Detour.Crowd
                         ag.corridor.Reset(agentRef, agentPos);
                         ag.partial = false;
                         ag.targetState = DtMoveRequestState.DT_CROWDAGENT_TARGET_NONE;
+                        // Every other route to TARGET_NONE clears the desired velocity. Without this the
+                        // agent coasts on its last dvel, since nothing recomputes it once the target is gone.
+                        ag.dvel = RcVec3f.Zero;
                     }
                 }
 

--- a/Recast/Recast/Detour.Crowd/DtCrowd.cs
+++ b/Recast/Recast/Detour.Crowd/DtCrowd.cs
@@ -285,6 +285,57 @@ namespace Prowl.Recast.Detour.Crowd
             return ag;
         }
 
+        /// Move @p agent to @p pos snapped onto the navmesh, dropping its path, target and
+        /// velocity — the same state AddAgent leaves a new agent in. False, and the agent
+        /// untouched, when no polygon is near @p pos.
+        ///
+        /// The DtCrowdAgent object survives, so references held to it stay valid; removing and
+        /// re-adding the agent to teleport it does not.
+        public bool WarpAgent(DtCrowdAgent agent, RcVec3f pos)
+        {
+            // Identity, not presence: every crowd numbers its own agents from zero, so an agent
+            // belonging to another crowd would otherwise take a polyref from this navmesh.
+            if (agent == null || GetAgent(agent.idx) != agent)
+            {
+                return false;
+            }
+
+            IDtQueryFilter filter = GetFilter(agent.option.queryFilterType);
+            if (filter == null)
+            {
+                return false;
+            }
+
+            var status = _navQuery.FindNearestPoly(pos, _agentPlacementHalfExtents, filter, out var refs, out var nearestPt, out var _);
+            if (status.Failed() || refs == 0)
+            {
+                return false;
+            }
+
+            ResetMoveTarget(agent);
+
+            agent.corridor.Reset(refs, nearestPt);
+            agent.boundary.Reset();
+            agent.partial = false;
+
+            agent.topologyOptTime = 0;
+            agent.targetReplanTime = 0;
+            agent.targetReplanWaitTime = 0;
+            agent.nneis = 0;
+            agent.ncorners = 0;
+
+            agent.nvel = RcVec3f.Zero;
+            agent.vel = RcVec3f.Zero;
+            agent.npos = nearestPt;
+            agent.desiredSpeed = 0;
+
+            // A live animation would keep overwriting npos from the link the agent was crossing.
+            agent.animation.active = false;
+
+            agent.state = DtCrowdAgentState.DT_CROWDAGENT_STATE_WALKING;
+            return true;
+        }
+
         public DtCrowdAgent GetAgent(int idx)
         {
             return _agents.GetValueOrDefault(idx);
@@ -355,8 +406,11 @@ namespace Prowl.Recast.Detour.Crowd
         ///  @param[in]		pos		Target position, inside @p refs.
         ///  @param[in]		path	Polygon path from the agent's current polygon to @p refs.
         ///  @param[in]		npath	Number of polygons in @p path.
+        ///  @param[in]     partial True when @p path stops short of the requested destination.
+        ///                         Advisory only: the crowd clears it on any internal replan, so a
+        ///                         caller that needs it durably tracks the destination itself.
         /// @return True if the path was adopted.
-        public bool SetAgentPath(DtCrowdAgent agent, long refs, RcVec3f pos, Span<long> path, int npath)
+        public bool SetAgentPath(DtCrowdAgent agent, long refs, RcVec3f pos, Span<long> path, int npath, bool partial)
         {
             if (refs == 0 || npath <= 0 || npath > path.Length || path[npath - 1] != refs)
             {
@@ -368,7 +422,7 @@ namespace Prowl.Recast.Detour.Crowd
             agent.targetPathQueryResult = null;
             agent.targetReplan = false;
             agent.targetReplanTime = 0;
-            agent.partial = false;
+            agent.partial = partial;
 
             // Same order the planner uses when a path completes: install the corridor, force the
             // boundary to rebuild around it, then mark the target valid.
@@ -1096,6 +1150,13 @@ namespace Prowl.Recast.Detour.Crowd
 
                 if (ag.targetState == DtMoveRequestState.DT_CROWDAGENT_TARGET_NONE
                     || ag.targetState == DtMoveRequestState.DT_CROWDAGENT_TARGET_VELOCITY)
+                {
+                    continue;
+                }
+
+                // tmax below divides by maxSpeed, and a halted agent has none: it would enter the
+                // link with an infinite crossing time and never come off it.
+                if (ag.option.maxSpeed <= 0)
                 {
                     continue;
                 }

--- a/Recast/Recast/Detour.Crowd/DtCrowdAgent.cs
+++ b/Recast/Recast/Detour.Crowd/DtCrowdAgent.cs
@@ -157,7 +157,7 @@ namespace Prowl.Recast.Detour.Crowd
                 dir.X = dir0.X - dir1.X * len0 * 0.5f;
                 dir.Y = 0;
                 dir.Z = dir0.Z - dir1.Z * len0 * 0.5f;
-                dir = RcVec3f.Normalize(dir);
+                dir = RcVec.SafeNormalize(dir);
             }
 
             return dir;
@@ -170,7 +170,9 @@ namespace Prowl.Recast.Detour.Crowd
             {
                 dir = RcVec3f.Subtract(corners[0].pos, npos);
                 dir.Y = 0;
-                dir = RcVec3f.Normalize(dir);
+                // A corner can land on the agent - FindCorners keeps one carrying an off-mesh link
+                // however close it is - and Normalize turns that into NaN rather than zero.
+                dir = RcVec.SafeNormalize(dir);
             }
 
             return dir;

--- a/Recast/Recast/Detour.TileCache/DtTileCache.cs
+++ b/Recast/Recast/Detour.TileCache/DtTileCache.cs
@@ -44,19 +44,16 @@ namespace Prowl.Recast.Detour.TileCache
         private readonly DtTileCacheParams m_params;
         private readonly DtTileCacheStorageParams m_storageParams;
 
-        private readonly DtTileCacheAlloc m_talloc;
         private readonly IRcCompressor m_tcomp;
         private readonly IDtTileCacheMeshProcess m_tmproc;
 
-        /// Held for the life of the cache rather than made per tile: a context allocates
-        /// thread-local timer state, and tile builds run one at a time on a cache.
-        private readonly RcContext m_ctx = new RcContext();
+        /// Held for the life of the cache rather than made per tile: the caches inside it only pay
+        /// off across consecutive builds, and a cache's own builds run one at a time.
+        private readonly DtTileCacheBuildScratch m_scratch = new DtTileCacheBuildScratch();
 
-        /// Neighbour layers a tile's border reads, by tile ref (#BorderLayer). Dropped whenever a
-        /// tile or an obstacle changes, since both change what the layers say.
-        private readonly Dictionary<long, DtTileCacheLayer> m_borderLayers = new Dictionary<long, DtTileCacheLayer>();
-        private const int MaxCachedBorderLayers = 256;
-        private readonly List<long> m_neighbourRefs = new List<long>();
+        /// Bumped whenever a tile or an obstacle changes what the layers say, so a build scratch
+        /// can tell whether the neighbour layers it cached are still the truth.
+        private int m_tileEpoch;
 
         private readonly List<DtTileCacheObstacle> m_obstacles = new List<DtTileCacheObstacle>();
         private DtTileCacheObstacle m_nextFreeObstacle;
@@ -77,7 +74,6 @@ namespace Prowl.Recast.Detour.TileCache
             m_params = option;
             m_storageParams = storageParams;
             m_navmesh = navmesh;
-            m_talloc = new DtTileCacheAlloc(); // TODO: ikpil, improve pooling system
             m_tcomp = tcomp;
             m_tmproc = tmprocs;
 
@@ -277,7 +273,7 @@ namespace Prowl.Recast.Detour.TileCache
         public bool TryAddTile(byte[] data, int flags, out long refs)
         {
             refs = 0;
-            m_borderLayers.Clear();
+            m_tileEpoch++;
 
             // Make sure the data is in right format.
             RcByteBuffer buf = new RcByteBuffer(data);
@@ -399,7 +395,7 @@ namespace Prowl.Recast.Detour.TileCache
 
         private DtTileCacheLayerHeader FreeCompressedTile(long refs)
         {
-            m_borderLayers.Clear();
+            m_tileEpoch++;
 
             if (refs == 0)
             {
@@ -663,7 +659,7 @@ namespace Prowl.Recast.Detour.TileCache
                 // requests are about to change.
                 if (m_reqs.Count > 0)
                 {
-                    m_borderLayers.Clear();
+                    m_tileEpoch++;
                 }
 
                 // Process requests.
@@ -752,19 +748,19 @@ namespace Prowl.Recast.Detour.TileCache
 
         public void BuildNavMeshTile(long refs)
         {
-            int idx = DecodeTileIdTile(refs);
-            if (idx > m_params.maxTiles)
-            {
-                throw new Exception("Invalid tile index");
-            }
+            CommitTile(refs, BuildTileMeshData(refs, m_scratch));
+        }
 
-            DtCompressedTile tile = m_tiles[idx];
-            int salt = DecodeTileIdSalt(refs);
-            if (tile.salt != salt)
-            {
-                throw new Exception("Invalid tile salt");
-            }
-
+        /// The build half of a tile: compressed layer in, finished tile mesh out, or null for a
+        /// tile with nothing walkable left in it. Reads the cache's tiles and obstacles and touches
+        /// no navmesh state, so several tiles can be built at once with a
+        /// <see cref="DtTileCacheBuildScratch"/> each — provided nothing adds, removes or carves a
+        /// tile while they run. A scratch may be kept and reused; it notices when the tiles have
+        /// moved on. Publish the result with <see cref="CommitTile"/>.
+        public DtMeshData BuildTileMeshData(long refs, DtTileCacheBuildScratch scratch)
+        {
+            scratch.SyncTo(this, m_tileEpoch);
+            DtCompressedTile tile = ResolveTile(refs);
             int walkableClimbVx = (int)(m_params.walkableClimb / m_params.ch);
 
             // Decompress tile layer data.
@@ -783,26 +779,26 @@ namespace Prowl.Recast.Detour.TileCache
             RcCompactHeightfield chf = null;
             if (m_params.watershedPartition || m_params.detailSampleDist > 0)
             {
-                DtTileCacheBuilder.DtTileBorderGrid grid = BuildBorderGrid(tile, layer, DtTileCacheBuilder.SeamBorder);
+                DtTileCacheBuilder.DtTileBorderGrid grid = BuildBorderGrid(tile, layer, DtTileCacheBuilder.SeamBorder, scratch);
                 chf = DtTileCacheBuilder.ToCompactHeightfield(grid, m_params);
             }
 
             DtTileCacheContourSet lcset = m_params.watershedPartition
-                ? DtTileCacheBuilder.BuildTileCacheContoursWatershed(m_ctx, layer, chf, m_params)
+                ? DtTileCacheBuilder.BuildTileCacheContoursWatershed(scratch.Ctx, layer, chf, m_params)
                 : null;
             if (lcset == null)
             {
                 DtTileCacheBuilder.BuildTileCacheRegions(layer, walkableClimbVx);
-                lcset = DtTileCacheBuilder.BuildTileCacheContours(m_talloc, layer, walkableClimbVx, m_params.maxSimplificationError);
+                lcset = DtTileCacheBuilder.BuildTileCacheContours(scratch.Alloc, layer, walkableClimbVx, m_params.maxSimplificationError);
             }
 
             DtTileCachePolyMesh polyMesh = DtTileCacheBuilder.BuildTileCachePolyMesh(lcset, m_navmesh.GetMaxVertsPerPoly());
 
-            // Early out if the mesh tile is empty.
+            // Early out if the mesh tile is empty. Null rather than an empty DtMeshData, so
+            // CommitTile empties the position either way without a second emptiness test.
             if (polyMesh.npolys == 0)
             {
-                m_navmesh.RemoveTile(m_navmesh.GetTileRefAt(tile.header.tx, tile.header.ty, tile.header.tlayer));
-                return;
+                return null;
             }
 
             DtNavMeshCreateParams option = new DtNavMeshCreateParams();
@@ -825,20 +821,49 @@ namespace Prowl.Recast.Detour.TileCache
             option.bmin = tile.header.bmin;
             option.bmax = tile.header.bmax;
             if (chf != null)
-                DtTileCacheBuilder.BuildTileCacheDetailMesh(m_ctx, layer, chf, option, m_params);
+                DtTileCacheBuilder.BuildTileCacheDetailMesh(scratch.Ctx, layer, chf, option, m_params);
             if (m_tmproc != null)
             {
                 m_tmproc.Process(option);
             }
 
-            DtMeshData meshData = DtNavMeshBuilder.CreateNavMeshData(option);
-            // Remove existing tile.
+            return DtNavMeshBuilder.CreateNavMeshData(option);
+        }
+
+        /// The publish half: replaces whatever the navmesh holds at @p refs' position with
+        /// @p meshData, or empties the position when it is null. Touches the navmesh, so it runs one
+        /// tile at a time. Committing in ref order reproduces a serial build exactly — AddTile
+        /// inserts at the head of the position hash chain and connects neighbours in chain order,
+        /// so the link tables depend on commit order and nothing else.
+        public void CommitTile(long refs, DtMeshData meshData)
+        {
+            DtCompressedTile tile = ResolveTile(refs);
+
             m_navmesh.RemoveTile(m_navmesh.GetTileRefAt(tile.header.tx, tile.header.ty, tile.header.tlayer));
-            // Add new tile, or leave the location empty. if (navData) { // Let the
             if (meshData != null)
             {
                 m_navmesh.AddTile(meshData, 0, 0, out var result);
             }
+        }
+
+        private DtCompressedTile ResolveTile(long refs)
+        {
+            // >=, not >: the ref's tile field is masked to the tile bit width, which is a power of
+            // two and so wider than maxTiles unless maxTiles is one itself. At exactly maxTiles the
+            // old test fell through to an index out of range instead of saying what was wrong.
+            int idx = DecodeTileIdTile(refs);
+            if (idx >= m_params.maxTiles)
+            {
+                throw new Exception("Invalid tile index");
+            }
+
+            DtCompressedTile tile = m_tiles[idx];
+            if (tile.salt != DecodeTileIdSalt(refs))
+            {
+                throw new Exception("Invalid tile salt");
+            }
+
+            return tile;
         }
 
         /// Cuts every obstacle that reaches @p refs out of that tile's layer. Kept separate from
@@ -875,22 +900,15 @@ namespace Prowl.Recast.Detour.TileCache
         }
 
         /// A neighbour's layer as a tile's border reads it: decompressed, with the obstacles that
-        /// reach it already cut out, and kept until the tiles or obstacles change. A bake meshes
-        /// every tile, and each of those reads its eight neighbours, so without this every layer
-        /// is decompressed nine times over.
-        private DtTileCacheLayer BorderLayer(long refs, DtCompressedTile tile)
+        /// reach it already cut out, and kept in the scratch until the tiles or obstacles change.
+        private DtTileCacheLayer BorderLayer(long refs, DtCompressedTile tile, DtTileCacheBuildScratch scratch)
         {
-            if (m_borderLayers.TryGetValue(refs, out DtTileCacheLayer cached))
+            if (scratch.BorderLayers.TryGetValue(refs, out DtTileCacheLayer cached))
                 return cached;
 
             DtTileCacheLayer layer = DecompressTile(tile);
             MarkObstacles(layer, tile.header.bmin, refs);
-            // Bounded rather than grown without limit: a world of thousands of tiles would
-            // otherwise hold every one of them decompressed for the life of the cache.
-            if (m_borderLayers.Count >= MaxCachedBorderLayers)
-                m_borderLayers.Clear();
-
-            m_borderLayers[refs] = layer;
+            scratch.RememberBorderLayer(refs, layer);
             return layer;
         }
 
@@ -901,7 +919,7 @@ namespace Prowl.Recast.Detour.TileCache
         /// construction. Border cells with no neighbour stay empty, which is exactly a map
         /// perimeter. A neighbour stacking several vertical layers contributes, per cell, the
         /// layer nearest this tile's own surface at the adjacent edge.
-        private DtTileCacheBuilder.DtTileBorderGrid BuildBorderGrid(DtCompressedTile tile, DtTileCacheLayer layer, int border)
+        private DtTileCacheBuilder.DtTileBorderGrid BuildBorderGrid(DtCompressedTile tile, DtTileCacheLayer layer, int border, DtTileCacheBuildScratch scratch)
         {
             int w = layer.header.width, h = layer.header.height;
             var grid = new DtTileCacheBuilder.DtTileBorderGrid(w, h, border);
@@ -934,14 +952,14 @@ namespace Prowl.Recast.Detour.TileCache
                     if (dtx == 0 && dty == 0)
                         continue;
 
-                    m_neighbourRefs.Clear();
-                    GetTilesAt(tile.header.tx + dtx, tile.header.ty + dty, m_neighbourRefs);
-                    foreach (long r in m_neighbourRefs)
+                    scratch.NeighbourRefs.Clear();
+                    GetTilesAt(tile.header.tx + dtx, tile.header.ty + dty, scratch.NeighbourRefs);
+                    foreach (long r in scratch.NeighbourRefs)
                     {
                         DtCompressedTile nt = GetTileByRef(r);
                         if (nt?.header == null || nt.header.width != w || nt.header.height != h)
                             continue;
-                        DtTileCacheLayer nl = BorderLayer(r, nt);
+                        DtTileCacheLayer nl = BorderLayer(r, nt, scratch);
                         // Layer heights are relative to their own layer's base; rebase into ours.
                         int off = (int)Math.Round((nl.header.bmin.Y - layer.header.bmin.Y) / m_params.ch);
 

--- a/Recast/Recast/Detour.TileCache/DtTileCache.cs
+++ b/Recast/Recast/Detour.TileCache/DtTileCache.cs
@@ -694,13 +694,6 @@ namespace Prowl.Recast.Detour.TileCache
 
                             ob.pending.Add(j);
                         }
-
-                        // A footprint over a column with no compressed layer touches nothing, so the
-                        // per-tile loop below never runs for it: completing it here is what makes it
-                        // PROCESSED deterministically, rather than whenever some unrelated tile is
-                        // next rebuilt. Only a PROCESSED obstacle is re-listed against a layer added
-                        // there later.
-                        if (ob.pending.Count == 0) CompleteObstacle(ob);
                     }
                     else if (req.action == DtObstacleRequestAction.REQUEST_REMOVE)
                     {
@@ -717,11 +710,11 @@ namespace Prowl.Recast.Detour.TileCache
 
                             ob.pending.Add(j);
                         }
-
-                        // Same for a removal, where the slot is what waits: it only reaches EMPTY and
-                        // returns to the free list through CompleteObstacle, and nothing else frees it.
-                        if (ob.pending.Count == 0) CompleteObstacle(ob);
                     }
+
+                    // Either branch can leave nothing pending: a footprint over a column with no
+                    // compressed layer touches no tile, so the per-tile loop below never completes it.
+                    if (ob.pending.Count == 0) CompleteObstacle(ob);
                 }
 
                 m_reqs.Clear();
@@ -742,10 +735,8 @@ namespace Prowl.Recast.Detour.TileCache
                     if (ob.state == DtObstacleState.DT_OBSTACLE_PROCESSING
                         || ob.state == DtObstacleState.DT_OBSTACLE_REMOVING)
                     {
-                        // Only this obstacle's own last pending tile completes it, as ForgetTileRef
-                        // already required: an obstacle whose request has not been drained yet has an
-                        // empty list, and completing it on someone else's tile build left it PROCESSED
-                        // with a pending list nothing would ever drain.
+                        // An obstacle whose request is not drained yet has an empty pending list, and
+                        // completing it on another tile's build leaves a list nothing would ever drain.
                         if (ob.pending.Remove(refs) && 0 == ob.pending.Count)
                         {
                             CompleteObstacle(ob);

--- a/Recast/Recast/Detour.TileCache/DtTileCache.cs
+++ b/Recast/Recast/Detour.TileCache/DtTileCache.cs
@@ -780,11 +780,11 @@ namespace Prowl.Recast.Detour.TileCache
             if (m_params.watershedPartition || m_params.detailSampleDist > 0)
             {
                 DtTileCacheBuilder.DtTileBorderGrid grid = BuildBorderGrid(tile, layer, DtTileCacheBuilder.SeamBorder, scratch);
-                chf = DtTileCacheBuilder.ToCompactHeightfield(grid, m_params);
+                chf = DtTileCacheBuilder.ToCompactHeightfield(grid, m_params, scratch);
             }
 
             DtTileCacheContourSet lcset = m_params.watershedPartition
-                ? DtTileCacheBuilder.BuildTileCacheContoursWatershed(scratch.Ctx, layer, chf, m_params)
+                ? DtTileCacheBuilder.BuildTileCacheContoursWatershed(scratch.Ctx, scratch.Regions, layer, chf, m_params)
                 : null;
             if (lcset == null)
             {
@@ -922,7 +922,8 @@ namespace Prowl.Recast.Detour.TileCache
         private DtTileCacheBuilder.DtTileBorderGrid BuildBorderGrid(DtCompressedTile tile, DtTileCacheLayer layer, int border, DtTileCacheBuildScratch scratch)
         {
             int w = layer.header.width, h = layer.header.height;
-            var grid = new DtTileCacheBuilder.DtTileBorderGrid(w, h, border);
+            int cells = (w + border * 2) * (h + border * 2);
+            var grid = new DtTileCacheBuilder.DtTileBorderGrid(w, h, border, scratch.GridHeights(cells), scratch.GridAreas(cells));
 
             for (int z = 0; z < h; ++z)
             {

--- a/Recast/Recast/Detour.TileCache/DtTileCache.cs
+++ b/Recast/Recast/Detour.TileCache/DtTileCache.cs
@@ -264,6 +264,19 @@ namespace Prowl.Recast.Detour.TileCache
 
         public long AddTile(byte[] data, int flags)
         {
+            if (!TryAddTile(data, flags, out long refs))
+            {
+                throw new Exception("Out of storage");
+            }
+
+            return refs;
+        }
+
+        /// As AddTile, but reports an exhausted tile pool instead of throwing, for callers that can
+        /// carry on without the tile. @p refs is still 0 when the position and layer are taken.
+        public bool TryAddTile(byte[] data, int flags, out long refs)
+        {
+            refs = 0;
             m_borderLayers.Clear();
 
             // Make sure the data is in right format.
@@ -273,7 +286,7 @@ namespace Prowl.Recast.Detour.TileCache
             // Make sure the location is free.
             if (GetTileAt(header.tx, header.ty, header.tlayer) != null)
             {
-                return 0;
+                return true;
             }
 
             // Allocate a tile.
@@ -288,7 +301,7 @@ namespace Prowl.Recast.Detour.TileCache
             // Make sure we could allocate a tile.
             if (tile == null)
             {
-                throw new Exception("Out of storage");
+                return false;
             }
 
             // Insert tile into the position lut.
@@ -302,7 +315,8 @@ namespace Prowl.Recast.Detour.TileCache
             tile.compressed = Align4(buf.Position());
             tile.flags = flags;
 
-            return GetTileRef(tile);
+            refs = GetTileRef(tile);
+            return true;
         }
 
         private int Align4(int i)
@@ -310,7 +324,80 @@ namespace Prowl.Recast.Detour.TileCache
             return (i + 3) & (~3);
         }
 
+        /// Frees the compressed tile and the navmesh tile built from it. Leaving the latter behind
+        /// would keep a queryable surface at a position the cache no longer describes.
         public void RemoveTile(long refs)
+        {
+            DtTileCacheLayerHeader header = FreeCompressedTile(refs);
+            m_navmesh.RemoveTile(m_navmesh.GetTileRefAt(header.tx, header.ty, header.tlayer));
+            ForgetTileRef(refs);
+        }
+
+        /// Frees the compressed tile only, leaving the navmesh tile in place and the rebuild queue
+        /// still naming it. Preserves the behaviour package consumers had before RemoveTile grew
+        /// the rest.
+        public void RemoveCompressedTileOnly(long refs) => FreeCompressedTile(refs);
+
+        /// A freed ref is reissued with a fresh salt by the next add, so anything still holding it
+        /// would rebuild or carve whatever tile takes its place — and BuildNavMeshTile throws on a
+        /// stale one. Completing the obstacle here matters too: once the tile is gone the update
+        /// loop can no longer do it, and the obstacle sits in PROCESSING forever or leaks its slot.
+        private void ForgetTileRef(long refs)
+        {
+            if (m_updateSet.Remove(refs))
+            {
+                for (int i = m_update.Count; i > 0; i--)
+                {
+                    long queued = m_update.Dequeue();
+                    if (queued != refs)
+                    {
+                        m_update.Enqueue(queued);
+                    }
+                }
+            }
+
+            for (int i = 0; i < m_obstacles.Count; ++i)
+            {
+                DtTileCacheObstacle ob = m_obstacles[i];
+                ob.touched.Remove(refs);
+                if (ob.state != DtObstacleState.DT_OBSTACLE_PROCESSING && ob.state != DtObstacleState.DT_OBSTACLE_REMOVING)
+                {
+                    continue;
+                }
+
+                if (ob.pending.Remove(refs) && 0 == ob.pending.Count)
+                {
+                    CompleteObstacle(ob);
+                }
+            }
+        }
+
+        private void CompleteObstacle(DtTileCacheObstacle ob)
+        {
+            if (ob.state == DtObstacleState.DT_OBSTACLE_PROCESSING)
+            {
+                ob.state = DtObstacleState.DT_OBSTACLE_PROCESSED;
+                return;
+            }
+
+            if (ob.state != DtObstacleState.DT_OBSTACLE_REMOVING)
+            {
+                return;
+            }
+
+            ob.state = DtObstacleState.DT_OBSTACLE_EMPTY;
+            // Salt should never be zero.
+            ob.salt = (ob.salt + 1) & ((1 << 16) - 1);
+            if (ob.salt == 0)
+            {
+                ob.salt++;
+            }
+
+            ob.next = m_nextFreeObstacle;
+            m_nextFreeObstacle = ob;
+        }
+
+        private DtTileCacheLayerHeader FreeCompressedTile(long refs)
         {
             m_borderLayers.Clear();
 
@@ -332,8 +419,11 @@ namespace Prowl.Recast.Detour.TileCache
                 throw new Exception("Invalid tile salt");
             }
 
+            // Captured before the free nulls it.
+            DtTileCacheLayerHeader header = tile.header;
+
             // Remove tile from hash lookup.
-            int h = ComputeTileHash(tile.header.tx, tile.header.ty, m_tileLutMask);
+            int h = ComputeTileHash(header.tx, header.ty, m_tileLutMask);
             DtCompressedTile prev = null;
             DtCompressedTile cur = m_posLookup[h];
             while (cur != null)
@@ -371,6 +461,8 @@ namespace Prowl.Recast.Detour.TileCache
             // Add to free list.
             tile.next = m_nextFreeTile;
             m_nextFreeTile = tile;
+
+            return header;
         }
 
         // Cylinder obstacle
@@ -465,6 +557,45 @@ namespace Prowl.Recast.Detour.TileCache
             return m_obstacles[i];
         }
 
+        /// The obstacle's bounds widened by the seam border, because a tile reads that far into its
+        /// neighbours: a tile the obstacle only reaches through its border still has to rebuild, or
+        /// its seam keeps describing ground the neighbour has already cut away.
+        private void GetObstacleReachBounds(DtTileCacheObstacle ob, out RcVec3f bmin, out RcVec3f bmax)
+        {
+            bmin = new RcVec3f();
+            bmax = new RcVec3f();
+            GetObstacleBounds(ob, ref bmin, ref bmax);
+            float reach = DtTileCacheBuilder.SeamBorder * m_params.cs;
+            bmin.X -= reach;
+            bmin.Z -= reach;
+            bmax.X += reach;
+            bmax.Z += reach;
+        }
+
+        /// Re-lists the tiles each settled obstacle cuts, for a cache whose tiles were replaced
+        /// under it: a new tile at the same position has a new ref the obstacle does not hold, and
+        /// would rebuild without the carve. Call after the replacement tiles are added and before
+        /// they are rebuilt — this re-lists tiles but queues no rebuild of its own.
+        ///
+        /// Only obstacles in PROCESSED are re-listed; one still PROCESSING or REMOVING has a
+        /// pending list in flight that this would desync. Callers replace tiles with the cache
+        /// quiesced (Update reporting up to date), where no obstacle is in either state.
+        public void RefreshObstacleTouchedTiles()
+        {
+            for (int i = 0; i < m_obstacles.Count; ++i)
+            {
+                DtTileCacheObstacle ob = m_obstacles[i];
+                if (ob.state != DtObstacleState.DT_OBSTACLE_PROCESSED)
+                {
+                    continue;
+                }
+
+                GetObstacleReachBounds(ob, out RcVec3f bmin, out RcVec3f bmax);
+                int ntouched = 0;
+                QueryTiles(bmin, bmax, ob.touched, ref ntouched);
+            }
+        }
+
         private DtStatus QueryTiles(RcVec3f bmin, RcVec3f bmax, List<long> results, ref int ntouched)
         {
             results.Clear();
@@ -553,19 +684,7 @@ namespace Prowl.Recast.Detour.TileCache
 
                     if (req.action == DtObstacleRequestAction.REQUEST_ADD)
                     {
-                        // Find touched tiles. Widened by the seam border, because a tile reads
-                        // that far into its neighbours: a tile the obstacle only reaches through
-                        // its border still has to rebuild, or its seam keeps describing ground
-                        // the neighbour has already cut away.
-                        RcVec3f bmin = new RcVec3f();
-                        RcVec3f bmax = new RcVec3f();
-                        GetObstacleBounds(ob, ref bmin, ref bmax);
-                        float reach = DtTileCacheBuilder.SeamBorder * m_params.cs;
-                        bmin.X -= reach;
-                        bmin.Z -= reach;
-                        bmax.X += reach;
-                        bmax.Z += reach;
-
+                        GetObstacleReachBounds(ob, out RcVec3f bmin, out RcVec3f bmax);
                         int ntouched = 0;
                         QueryTiles(bmin, bmax, ob.touched, ref ntouched);
                         // Add tiles to update list.
@@ -622,24 +741,7 @@ namespace Prowl.Recast.Detour.TileCache
                         // If all pending tiles processed, change state.
                         if (0 == ob.pending.Count)
                         {
-                            if (ob.state == DtObstacleState.DT_OBSTACLE_PROCESSING)
-                            {
-                                ob.state = DtObstacleState.DT_OBSTACLE_PROCESSED;
-                            }
-                            else if (ob.state == DtObstacleState.DT_OBSTACLE_REMOVING)
-                            {
-                                ob.state = DtObstacleState.DT_OBSTACLE_EMPTY;
-                                // Update salt, salt should never be zero.
-                                ob.salt = (ob.salt + 1) & ((1 << 16) - 1);
-                                if (ob.salt == 0)
-                                {
-                                    ob.salt++;
-                                }
-
-                                // Return obstacle to free list.
-                                ob.next = m_nextFreeObstacle;
-                                m_nextFreeObstacle = ob;
-                            }
+                            CompleteObstacle(ob);
                         }
                     }
                 }

--- a/Recast/Recast/Detour.TileCache/DtTileCache.cs
+++ b/Recast/Recast/Detour.TileCache/DtTileCache.cs
@@ -694,6 +694,13 @@ namespace Prowl.Recast.Detour.TileCache
 
                             ob.pending.Add(j);
                         }
+
+                        // A footprint over a column with no compressed layer touches nothing, so the
+                        // per-tile loop below never runs for it: completing it here is what makes it
+                        // PROCESSED deterministically, rather than whenever some unrelated tile is
+                        // next rebuilt. Only a PROCESSED obstacle is re-listed against a layer added
+                        // there later.
+                        if (ob.pending.Count == 0) CompleteObstacle(ob);
                     }
                     else if (req.action == DtObstacleRequestAction.REQUEST_REMOVE)
                     {
@@ -710,6 +717,10 @@ namespace Prowl.Recast.Detour.TileCache
 
                             ob.pending.Add(j);
                         }
+
+                        // Same for a removal, where the slot is what waits: it only reaches EMPTY and
+                        // returns to the free list through CompleteObstacle, and nothing else frees it.
+                        if (ob.pending.Count == 0) CompleteObstacle(ob);
                     }
                 }
 
@@ -731,11 +742,11 @@ namespace Prowl.Recast.Detour.TileCache
                     if (ob.state == DtObstacleState.DT_OBSTACLE_PROCESSING
                         || ob.state == DtObstacleState.DT_OBSTACLE_REMOVING)
                     {
-                        // Remove handled tile from pending list.
-                        ob.pending.Remove(refs);
-
-                        // If all pending tiles processed, change state.
-                        if (0 == ob.pending.Count)
+                        // Only this obstacle's own last pending tile completes it, as ForgetTileRef
+                        // already required: an obstacle whose request has not been drained yet has an
+                        // empty list, and completing it on someone else's tile build left it PROCESSED
+                        // with a pending list nothing would ever drain.
+                        if (ob.pending.Remove(refs) && 0 == ob.pending.Count)
                         {
                             CompleteObstacle(ob);
                         }

--- a/Recast/Recast/Detour.TileCache/DtTileCacheBuildScratch.cs
+++ b/Recast/Recast/Detour.TileCache/DtTileCacheBuildScratch.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+
+using Prowl.Recast.Core;
+
+namespace Prowl.Recast.Detour.TileCache
+{
+    /// The working set one tile build needs to itself. A cache holds one of these for its own
+    /// builds; a caller meshing several tiles at once (registration, which starts from a full set
+    /// of compressed layers) gives each thread its own and hands them to
+    /// <see cref="DtTileCache.BuildTileMeshData"/>.
+    ///
+    /// Everything here is either stateful per build (the context's timers, the allocator) or a
+    /// cache that only pays off across consecutive builds (the neighbour layers). The compressor
+    /// and the obstacle list are NOT here: those are read-only during a build and shared.
+    public sealed class DtTileCacheBuildScratch
+    {
+        /// Bounded rather than grown without limit: a world of thousands of tiles would otherwise
+        /// hold every one of them decompressed for the life of the cache.
+        private const int MaxCachedBorderLayers = 256;
+
+        /// A context allocates thread-local timer state, so it cannot be shared across threads.
+        internal readonly RcContext Ctx = new RcContext();
+
+        internal readonly DtTileCacheAlloc Alloc = new DtTileCacheAlloc();
+
+        /// Neighbour layers a tile's border reads, by tile ref. A bake meshes every tile and each
+        /// reads its eight neighbours, so without this every layer is decompressed nine times over.
+        /// Dropped whenever a tile or an obstacle changes, since both change what the layers say.
+        internal readonly Dictionary<long, DtTileCacheLayer> BorderLayers = new Dictionary<long, DtTileCacheLayer>();
+
+        internal readonly List<long> NeighbourRefs = new List<long>();
+
+        private DtTileCache m_owner;
+        private int m_epoch = -1;
+
+        /// Drops the neighbour layers when they can no longer be trusted: a different cache (refs
+        /// are per-cache, so one cache's ref names another's tile), or the same cache after a tile
+        /// or obstacle changed what its layers say. Without this, holding a scratch across an
+        /// AddTile or a carve would silently build seams from the layers as they used to be.
+        internal void SyncTo(DtTileCache owner, int epoch)
+        {
+            if (ReferenceEquals(m_owner, owner) && m_epoch == epoch)
+            {
+                return;
+            }
+
+            BorderLayers.Clear();
+            m_owner = owner;
+            m_epoch = epoch;
+        }
+
+        internal void RememberBorderLayer(long refs, DtTileCacheLayer layer)
+        {
+            if (BorderLayers.Count >= MaxCachedBorderLayers)
+            {
+                BorderLayers.Clear();
+            }
+
+            BorderLayers[refs] = layer;
+        }
+    }
+}

--- a/Recast/Recast/Detour.TileCache/DtTileCacheBuildScratch.cs
+++ b/Recast/Recast/Detour.TileCache/DtTileCacheBuildScratch.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using Prowl.Recast.Core;
@@ -23,6 +24,9 @@ namespace Prowl.Recast.Detour.TileCache
 
         internal readonly DtTileCacheAlloc Alloc = new DtTileCacheAlloc();
 
+        /// The region partitioner.s working buffers, a quarter of a build.s allocation on their own.
+        internal readonly RcRegionScratch Regions = new RcRegionScratch();
+
         /// Neighbour layers a tile's border reads, by tile ref. A bake meshes every tile and each
         /// reads its eight neighbours, so without this every layer is decompressed nine times over.
         /// Dropped whenever a tile or an obstacle changes, since both change what the layers say.
@@ -47,6 +51,54 @@ namespace Prowl.Recast.Detour.TileCache
             BorderLayers.Clear();
             m_owner = owner;
             m_epoch = epoch;
+        }
+
+        // Grow-only working buffers for the biggest arrays a tile build makes. They are sized by the
+        // tile's cell and span counts, which barely move from tile to tile, so after the first build
+        // a scratch stops allocating them: measured at 28% of a build's total allocation, and every
+        // carve pays it again. Only the used prefix of each is ever read — nothing on this path
+        // iterates one by Length — so an oversized buffer is as good as an exact one.
+        private int[] m_gridHeights = Array.Empty<int>();
+        private int[] m_gridAreas = Array.Empty<int>();
+        private RcCompactCell[] m_chfCells = Array.Empty<RcCompactCell>();
+        private RcCompactSpan[] m_chfSpans = Array.Empty<RcCompactSpan>();
+        private int[] m_chfAreas = Array.Empty<int>();
+        private RcCompactHeightfield m_chf;
+
+        internal int[] GridHeights(int size) => Grow(ref m_gridHeights, size);
+
+        internal int[] GridAreas(int size) => Grow(ref m_gridAreas, size);
+
+        internal RcCompactCell[] ChfCells(int size) => Grow(ref m_chfCells, size);
+
+        internal RcCompactSpan[] ChfSpans(int size) => Grow(ref m_chfSpans, size);
+
+        internal int[] ChfAreas(int size) => Grow(ref m_chfAreas, size);
+
+        /// The heightfield object itself, reused. Every field the tile-cache path reads is written
+        /// before it is read — the converter sets all of them bar bmin/bmax, which stay at zero as
+        /// they did on a fresh one, and the distance field and regions assign theirs each build.
+        internal RcCompactHeightfield Chf
+        {
+            get
+            {
+                if (m_chf == null)
+                {
+                    m_chf = new RcCompactHeightfield();
+                }
+
+                return m_chf;
+            }
+        }
+
+        private static T[] Grow<T>(ref T[] buffer, int size)
+        {
+            if (buffer.Length < size)
+            {
+                buffer = new T[size];
+            }
+
+            return buffer;
         }
 
         internal void RememberBorderLayer(long refs, DtTileCacheLayer layer)

--- a/Recast/Recast/Detour.TileCache/DtTileCacheBuilder.cs
+++ b/Recast/Recast/Detour.TileCache/DtTileCacheBuilder.cs
@@ -2123,14 +2123,26 @@ namespace Prowl.Recast.Detour.TileCache
             public readonly int[] areas;
 
             public DtTileBorderGrid(int width, int height, int border)
+                : this(width, height, border,
+                    new int[(width + border * 2) * (height + border * 2)],
+                    new int[(width + border * 2) * (height + border * 2)])
+            {
+            }
+
+            /// Over caller-owned buffers, each at least (width + 2*border) * (height + 2*border)
+            /// long. Only that prefix is touched — and it is reset here, since a border cell no
+            /// neighbour covers is left as it was found — so a buffer grown for a bigger tile can be
+            /// handed back for a smaller one.
+            public DtTileBorderGrid(int width, int height, int border, int[] heights, int[] areas)
             {
                 this.width = width;
                 this.height = height;
                 this.border = border;
-                int gw = width + border * 2, gh = height + border * 2;
-                heights = new int[gw * gh];
-                areas = new int[gw * gh];
-                Array.Fill(heights, -1);
+                this.heights = heights;
+                this.areas = areas;
+                int cells = (width + border * 2) * (height + border * 2);
+                Array.Fill(heights, -1, 0, cells);
+                Array.Clear(areas, 0, cells);
             }
 
             /// Index by core cell coordinates; the border lives at -border..-1 and width..width+border-1.
@@ -2155,7 +2167,7 @@ namespace Prowl.Recast.Detour.TileCache
         /// Tile seams still stitch: portal edges lie exactly on the tile boundary lines, where
         /// simplification cannot move them, and each converted edge takes its portal direction
         /// from the layer's own connection bits.
-        public static DtTileCacheContourSet BuildTileCacheContoursWatershed(RcContext ctx, DtTileCacheLayer layer,
+        public static DtTileCacheContourSet BuildTileCacheContoursWatershed(RcContext ctx, RcRegionScratch regionScratch, DtTileCacheLayer layer,
             RcCompactHeightfield chf, in DtTileCacheParams cacheParams)
         {
             if (HasInteriorLayerPortals(layer))
@@ -2165,7 +2177,7 @@ namespace Prowl.Recast.Detour.TileCache
             try
             {
                 RcRegions.BuildDistanceField(ctx, chf);
-                RcRegions.BuildRegions(ctx, chf, cacheParams.minRegionArea, cacheParams.mergeRegionArea);
+                RcRegions.BuildRegions(ctx, chf, cacheParams.minRegionArea, cacheParams.mergeRegionArea, regionScratch);
                 rcset = RcContours.BuildContours(ctx, chf, cacheParams.maxSimplificationError,
                     cacheParams.maxEdgeLen, RcBuildContoursFlags.RC_CONTOUR_TESS_WALL_EDGES);
             }
@@ -2731,8 +2743,11 @@ namespace Prowl.Recast.Detour.TileCache
         /// case in a built environment, and this runs on every tile build rather than once.
         private static bool IsLevel(DtTileCacheLayer layer)
         {
+            // The header's extent, not the array's: a layer may be carried in a buffer sized for a
+            // bigger tile, and its tail says nothing about this one.
             int height = -1;
-            for (int i = 0; i < layer.heights.Length; i++)
+            int cells = layer.header.width * layer.header.height;
+            for (int i = 0; i < cells; i++)
             {
                 if (layer.heights[i] == NoSurface) continue;
                 if (height < 0) height = layer.heights[i];
@@ -2752,7 +2767,10 @@ namespace Prowl.Recast.Detour.TileCache
         /// Spans pack densely, exactly like a real compact heightfield: array-wide passes index by
         /// span, so padded slots would leak their sentinel values into the aggregates those passes
         /// take.
-        public static RcCompactHeightfield ToCompactHeightfield(DtTileBorderGrid grid, in DtTileCacheParams cacheParams)
+        /// Taking the heightfield and its arrays from <paramref name="scratch"/> when one is given,
+        /// so a build that runs per carve stops re-allocating them; null allocates per call.
+        public static RcCompactHeightfield ToCompactHeightfield(DtTileBorderGrid grid, in DtTileCacheParams cacheParams,
+            DtTileCacheBuildScratch scratch)
         {
             int b = grid.border;
             int width = grid.width + b * 2, depth = grid.height + b * 2;
@@ -2762,7 +2780,7 @@ namespace Prowl.Recast.Detour.TileCache
                 if (grid.heights[i] >= 0)
                     spanCount++;
 
-            RcCompactHeightfield chf = new RcCompactHeightfield();
+            RcCompactHeightfield chf = scratch != null ? scratch.Chf : new RcCompactHeightfield();
             chf.width = width;
             chf.height = depth;
             chf.borderSize = b;
@@ -2771,9 +2789,16 @@ namespace Prowl.Recast.Detour.TileCache
             chf.walkableClimb = (int)MathF.Floor(cacheParams.walkableClimb / cacheParams.ch);
             chf.cs = cacheParams.cs;
             chf.ch = cacheParams.ch;
-            chf.cells = new RcCompactCell[width * depth];
-            chf.spans = new RcCompactSpan[spanCount];
-            chf.areas = new int[spanCount];
+            chf.cells = scratch != null ? scratch.ChfCells(width * depth) : new RcCompactCell[width * depth];
+            chf.spans = scratch != null ? scratch.ChfSpans(spanCount) : new RcCompactSpan[spanCount];
+            chf.areas = scratch != null ? scratch.ChfAreas(spanCount) : new int[spanCount];
+
+            // The fields the later stages own, back to what a fresh heightfield would carry. Nothing
+            // on this path reads them before they are written, and this is what keeps that true: a
+            // reused heightfield would otherwise hand the previous tile's numbers to whoever starts.
+            chf.dist = null;
+            chf.maxDistance = 0;
+            chf.maxRegions = 0;
 
             RcCompactSpanBuilder span = RcCompactSpanBuilder.NewBuilder();
             int cur = 0;

--- a/Recast/Recast/Recast/RcMeshDetails.cs
+++ b/Recast/Recast/Recast/RcMeshDetails.cs
@@ -1068,8 +1068,12 @@ namespace Prowl.Recast
         }
 
 
+        /// deadEndCategory is what to log if the walk cannot reach the centre. The caller decides:
+        /// seeding from the centre is the designed path for a polygon with no single region, so a
+        /// dead-end there is a quality note; anywhere else it means the height patch is seeded off a
+        /// cell the polygon may not own, and the BFS that follows assumes otherwise.
         public static void SeedArrayWithPolyCenter(RcContext ctx, RcCompactHeightfield chf, int[] meshpoly, int poly, int npoly,
-            int[] verts, int bs, RcHeightPatch hp, List<int> array)
+            int[] verts, int bs, RcHeightPatch hp, List<int> array, RcLogCategory deadEndCategory)
         {
             // Note: Reads to the compact heightfield are offset by border size (bs)
             // since border size offset is already removed from the polymesh vertices.
@@ -1133,7 +1137,8 @@ namespace Prowl.Recast
             {
                 if (array.Count < 3)
                 {
-                    ctx.Warn("Walk towards polygon center failed to reach center");
+                    ctx.Log(deadEndCategory,
+                        "GetHeightData: seed walk stopped short of the polygon centre; height patch seeded off-centre");
                     break;
                 }
 
@@ -1298,7 +1303,11 @@ namespace Prowl.Recast
             // then use the center as the seed point.
             if (empty)
             {
-                SeedArrayWithPolyCenter(ctx, chf, meshpolys, poly, npoly, verts, bs, hp, queue);
+                // A polygon with no single region is seeded from its centre by design, and every
+                // polygon takes that path on the tile-cache route, where the poly mesh carries no
+                // region ids at all — so a dead-end there is expected rather than a fault.
+                SeedArrayWithPolyCenter(ctx, chf, meshpolys, poly, npoly, verts, bs, hp, queue,
+                    region == RcRecast.RC_MULTIPLE_REGS ? RcLogCategory.RC_LOG_PROGRESS : RcLogCategory.RC_LOG_WARNING);
             }
 
             const int RETRACT_SIZE = 256;

--- a/Recast/Recast/Recast/RcMeshDetails.cs
+++ b/Recast/Recast/Recast/RcMeshDetails.cs
@@ -587,7 +587,6 @@ namespace Prowl.Recast
                 int t = i * 4;
                 if (tris[t + 0] == -1 || tris[t + 1] == -1 || tris[t + 2] == -1)
                 {
-                    Console.Error.WriteLine($"delaunayHull: Removing dangling face {i} [{tris[t]},{tris[t + 1]},{tris[t + 2]}]");
                     tris[t + 0] = tris[tris.Count - 4];
                     tris[t + 1] = tris[tris.Count - 3];
                     tris[t + 2] = tris[tris.Count - 2];

--- a/Recast/Recast/Recast/RcMeshDetails.cs
+++ b/Recast/Recast/Recast/RcMeshDetails.cs
@@ -1068,10 +1068,8 @@ namespace Prowl.Recast
         }
 
 
-        /// deadEndCategory is what to log if the walk cannot reach the centre. The caller decides:
-        /// seeding from the centre is the designed path for a polygon with no single region, so a
-        /// dead-end there is a quality note; anywhere else it means the height patch is seeded off a
-        /// cell the polygon may not own, and the BFS that follows assumes otherwise.
+        /// deadEndCategory is what to log if the walk cannot reach the centre: expected where
+        /// centre-seeding is by design, elsewhere a patch seeded off a cell the polygon may not own.
         public static void SeedArrayWithPolyCenter(RcContext ctx, RcCompactHeightfield chf, int[] meshpoly, int poly, int npoly,
             int[] verts, int bs, RcHeightPatch hp, List<int> array, RcLogCategory deadEndCategory)
         {
@@ -1303,9 +1301,8 @@ namespace Prowl.Recast
             // then use the center as the seed point.
             if (empty)
             {
-                // A polygon with no single region is seeded from its centre by design, and every
-                // polygon takes that path on the tile-cache route, where the poly mesh carries no
-                // region ids at all — so a dead-end there is expected rather than a fault.
+                // On the tile-cache route the poly mesh carries no region ids, so every polygon is
+                // seeded from its centre and a dead-end there is expected rather than a fault.
                 SeedArrayWithPolyCenter(ctx, chf, meshpolys, poly, npoly, verts, bs, hp, queue,
                     region == RcRecast.RC_MULTIPLE_REGS ? RcLogCategory.RC_LOG_PROGRESS : RcLogCategory.RC_LOG_WARNING);
             }

--- a/Recast/Recast/Recast/RcRegionScratch.cs
+++ b/Recast/Recast/Recast/RcRegionScratch.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+
+namespace Prowl.Recast
+{
+    /// The working buffers one <see cref="RcRegions.BuildRegions"/> call needs, kept so a caller
+    /// that partitions heightfield after heightfield — a tile cache carving a tile per frame, a bake
+    /// walking a tile grid — stops re-allocating them. Measured at roughly a quarter of a tile
+    /// build's total allocation.
+    ///
+    /// Grow-only, and a buffer grown for a larger heightfield is handed back for a smaller one, so
+    /// nothing may read past the span count it was asked for.
+    /// One per thread: a partitioner run holds this for its duration, so two at once need two.
+    public sealed class RcRegionScratch
+    {
+        private int[] m_srcReg = Array.Empty<int>();
+        private int[] m_srcDist = Array.Empty<int>();
+        private List<List<RcLevelStackEntry>> m_lvlStacks;
+        private List<RcLevelStackEntry> m_stack;
+
+        /// Zeroed to <paramref name="spanCount"/>: the partitioner reads 0 as "no region assigned
+        /// yet", so ids left in a longer buffer's tail would seed regions that do not exist.
+        internal int[] SrcReg(int spanCount) => Cleared(ref m_srcReg, spanCount);
+
+        /// Zeroed for symmetry with <see cref="SrcReg"/> rather than out of need — every path that
+        /// reads a distance wrote it in the same statement that made its region id positive.
+        internal int[] SrcDist(int spanCount) => Cleared(ref m_srcDist, spanCount);
+
+        /// The per-level stacks, emptied. The partitioner does refill each one before reading it,
+        /// but only because its first pass through the level loop is the one that sorts — an
+        /// ordering three methods deep. Emptying them here costs nothing (the entry is a struct, so
+        /// Clear just resets a count) and makes a stale entry impossible rather than unreachable.
+        internal List<List<RcLevelStackEntry>> LevelStacks()
+        {
+            if (m_lvlStacks == null)
+            {
+                m_lvlStacks = new List<List<RcLevelStackEntry>>(RcRegions.NB_STACKS);
+                for (int i = 0; i < RcRegions.NB_STACKS; ++i)
+                {
+                    m_lvlStacks.Add(new List<RcLevelStackEntry>(256));
+                }
+            }
+
+            for (int i = 0; i < m_lvlStacks.Count; ++i)
+            {
+                m_lvlStacks[i].Clear();
+            }
+
+            return m_lvlStacks;
+        }
+
+        /// The flood stack. Every user of it clears before filling, so this does not.
+        internal List<RcLevelStackEntry> Stack()
+        {
+            if (m_stack == null)
+            {
+                m_stack = new List<RcLevelStackEntry>(256);
+            }
+
+            return m_stack;
+        }
+
+        private static int[] Cleared(ref int[] buffer, int size)
+        {
+            if (buffer.Length < size)
+            {
+                buffer = new int[size];
+                return buffer;
+            }
+
+            Array.Clear(buffer, 0, size);
+            return buffer;
+        }
+    }
+}

--- a/Recast/Recast/Recast/RcRegions.cs
+++ b/Recast/Recast/Recast/RcRegions.cs
@@ -32,6 +32,10 @@ namespace Prowl.Recast
     {
         const int RC_NULL_NEI = 0xffff;
 
+        /// Level stacks the watershed pass rotates through, shared with RcRegionScratch so the pooled
+        /// set cannot be sized differently from the loop that indexes it.
+        internal const int NB_STACKS = 8;
+
         public static int CalculateDistanceField(RcCompactHeightfield chf, int[] src)
         {
             int maxDist;
@@ -300,7 +304,6 @@ namespace Prowl.Recast
                 int cy = back.y;
                 int ci = back.index;
                 stack.RemoveAt(stack.Count - 1);
-
 
                 ref RcCompactSpan cs = ref chf.spans[ci];
 
@@ -572,7 +575,6 @@ namespace Prowl.Recast
                 dstStack.Add(srcStack[j]);
             }
         }
-
 
         private static void RemoveAdjacentNeighbours(RcRegion reg)
         {
@@ -1656,6 +1658,13 @@ namespace Prowl.Recast
         /// @see rcCompactHeightfield, rcCompactSpan, rcBuildDistanceField, rcBuildRegionsMonotone, rcConfig
         public static void BuildRegions(RcContext ctx, RcCompactHeightfield chf, int minRegionArea,
             int mergeRegionArea)
+            => BuildRegions(ctx, chf, minRegionArea, mergeRegionArea, null);
+
+        /// <inheritdoc cref="BuildRegions(RcContext, RcCompactHeightfield, int, int)"/>
+        /// Taking its working buffers from @p scratch when one is given, which is what a caller
+        /// partitioning one heightfield after another wants; null allocates them per call as before.
+        public static void BuildRegions(RcContext ctx, RcCompactHeightfield chf, int minRegionArea,
+            int mergeRegionArea, RcRegionScratch scratch)
         {
             using var timer = ctx.ScopedTimer(RcTimerLabel.RC_TIMER_BUILD_REGIONS);
 
@@ -1665,18 +1674,24 @@ namespace Prowl.Recast
 
             ctx.StartTimer(RcTimerLabel.RC_TIMER_BUILD_REGIONS_WATERSHED);
 
-            const int LOG_NB_STACKS = 3;
-            const int NB_STACKS = 1 << LOG_NB_STACKS;
-            List<List<RcLevelStackEntry>> lvlStacks = new List<List<RcLevelStackEntry>>();
-            for (int i = 0; i < NB_STACKS; ++i)
+            List<List<RcLevelStackEntry>> lvlStacks;
+            if (scratch != null)
             {
-                lvlStacks.Add(new List<RcLevelStackEntry>(256));
+                lvlStacks = scratch.LevelStacks();
+            }
+            else
+            {
+                lvlStacks = new List<List<RcLevelStackEntry>>();
+                for (int i = 0; i < NB_STACKS; ++i)
+                {
+                    lvlStacks.Add(new List<RcLevelStackEntry>(256));
+                }
             }
 
-            List<RcLevelStackEntry> stack = new List<RcLevelStackEntry>(256);
+            List<RcLevelStackEntry> stack = scratch != null ? scratch.Stack() : new List<RcLevelStackEntry>(256);
 
-            int[] srcReg = new int[chf.spanCount];
-            int[] srcDist = new int[chf.spanCount];
+            int[] srcReg = scratch != null ? scratch.SrcReg(chf.spanCount) : new int[chf.spanCount];
+            int[] srcDist = scratch != null ? scratch.SrcDist(chf.spanCount) : new int[chf.spanCount];
 
             int regionId = 1;
             int level = (chf.maxDistance + 1) & ~1;

--- a/Recast/Tests/Detour.Crowd/DtCrowdAgentControlTest.cs
+++ b/Recast/Tests/Detour.Crowd/DtCrowdAgentControlTest.cs
@@ -1,0 +1,89 @@
+using Prowl.Recast.Core.Numerics;
+
+namespace Prowl.Recast.Detour.Crowd.Tests;
+
+/// Direct control over an agent already in the crowd: teleporting it and installing a path.
+public class DtCrowdAgentControlTest : AbstractCrowdTest
+{
+    private DtCrowdAgent AddOne() => crowd.AddAgent(startPoss[0], GetAgentParams(0, 0));
+
+    [Fact]
+    public void WarpAgent_PlacesTheAgentAndKeepsTheObject()
+    {
+        DtCrowdAgent agent = AddOne();
+        SetMoveTarget(endPoss[0], false);
+        crowd.Update(0.1f, null);
+
+        Assert.True(crowd.WarpAgent(agent, endPoss[0]));
+
+        Assert.Same(agent, crowd.GetAgent(agent.idx));
+        Assert.True(RcVec.Dist2D(agent.npos, endPoss[0]) < 1f);
+        Assert.Equal(DtCrowdAgentState.DT_CROWDAGENT_STATE_WALKING, agent.state);
+        Assert.Equal(DtMoveRequestState.DT_CROWDAGENT_TARGET_NONE, agent.targetState);
+        Assert.Equal(0, agent.targetRef);
+        Assert.Equal(RcVec3f.Zero, agent.vel);
+        Assert.Equal(RcVec3f.Zero, agent.dvel);
+        Assert.Equal(0, agent.ncorners);
+
+        // The corridor has to move with it. Left behind, the agent steps from its old polygon the
+        // moment it is given a target again.
+        Assert.Equal(endRefs[0], agent.corridor.GetFirstPoly());
+        Assert.True(RcVec.Dist2D(agent.corridor.GetPos(), endPoss[0]) < 1f);
+    }
+
+    [Fact]
+    public void WarpAgent_OnAnAgentOfAnotherCrowd_ReturnsFalse()
+    {
+        DtCrowdAgent agent = AddOne();
+        var other = new DtCrowd(new DtCrowdConfig(0.6f), navmesh);
+
+        Assert.False(other.WarpAgent(agent, endPoss[0]));
+    }
+
+    [Fact]
+    public void WarpAgent_OffTheNavMesh_ReturnsFalseAndLeavesTheAgent()
+    {
+        DtCrowdAgent agent = AddOne();
+        RcVec3f before = agent.npos;
+
+        Assert.False(crowd.WarpAgent(agent, new RcVec3f(10000f, 10000f, 10000f)));
+
+        Assert.Equal(before, agent.npos);
+    }
+
+    /// A live animation lerps npos from the link's endpoints, so one left running drags the agent
+    /// off the position it was warped to.
+    [Fact]
+    public void WarpAgent_ClearsAnActiveLinkAnimation()
+    {
+        DtCrowdAgent agent = AddOne();
+        DtCrowdAgentAnimation anim = agent.animation;
+        anim.active = true;
+        anim.t = 0f;
+        anim.tmax = 10f;
+        anim.initPos = startPoss[0];
+        anim.startPos = startPoss[0];
+        anim.endPos = startPoss[1];
+        agent.state = DtCrowdAgentState.DT_CROWDAGENT_STATE_OFFMESH;
+
+        Assert.True(crowd.WarpAgent(agent, endPoss[0]));
+        Assert.False(anim.active);
+        Assert.Equal(DtCrowdAgentState.DT_CROWDAGENT_STATE_WALKING, agent.state);
+
+        crowd.Update(0.1f, null);
+        Assert.True(RcVec.Dist2D(agent.npos, endPoss[0]) < 1f);
+    }
+
+    [Fact]
+    public void SetAgentPath_HonoursThePartialFlag()
+    {
+        DtCrowdAgent agent = AddOne();
+        long[] path = [startRefs[0]];
+
+        Assert.True(crowd.SetAgentPath(agent, startRefs[0], startPoss[0], path, 1, true));
+        Assert.True(agent.partial);
+
+        Assert.True(crowd.SetAgentPath(agent, startRefs[0], startPoss[0], path, 1, false));
+        Assert.False(agent.partial);
+    }
+}

--- a/Recast/Tests/Detour.Crowd/DtCrowdSteeringStateTest.cs
+++ b/Recast/Tests/Detour.Crowd/DtCrowdSteeringStateTest.cs
@@ -1,0 +1,52 @@
+using Prowl.Recast.Core.Numerics;
+
+namespace Prowl.Recast.Detour.Crowd.Tests;
+
+/// What the crowd leaves in an agent's steering state when there is nothing valid to steer toward.
+/// Both cases used to leave a value that only looked harmless because obstacle avoidance recomputed
+/// over it every frame.
+public class DtCrowdSteeringStateTest : AbstractCrowdTest
+{
+    [Fact]
+    public void LosingTheMoveTarget_ClearsDesiredVelocityAndStopsTheAgent()
+    {
+        DtCrowdAgent agent = crowd.AddAgent(startPoss[0], GetAgentParams(0, 0));
+        SetMoveTarget(endPoss[0], false);
+
+        // Up to speed first, so there is a desired velocity to leave behind.
+        for (int i = 0; i < 10; i++)
+            crowd.Update(0.1f, null);
+        Assert.True(agent.dvel.Length() > 0.1f, "the agent has to be steering before its target is taken away");
+
+        // The destination polygon is gone and nothing near the old position replaces it, which is
+        // what an obstacle carved over the target leaves behind.
+        agent.targetRef = 0;
+        agent.targetPos = new RcVec3f(10000f, 10000f, 10000f);
+        crowd.Update(0.1f, null);
+
+        Assert.Equal(DtMoveRequestState.DT_CROWDAGENT_TARGET_NONE, agent.targetState);
+        Assert.Equal(RcVec3f.Zero, agent.dvel);
+
+        // Nothing recomputes dvel once the target is gone, so a stale one is walked forever.
+        RcVec3f stoppedAt = agent.npos;
+        for (int i = 0; i < 20; i++)
+            crowd.Update(0.1f, null);
+
+        Assert.True(agent.vel.Length() < 0.01f, $"still moving at {agent.vel.Length():0.###}");
+        float coasted = RcVec.Dist2D(agent.npos, stoppedAt);
+        Assert.True(coasted < 1.5f, $"coasted a further {coasted:0.##} after braking");
+    }
+
+    /// FindCorners prunes a corner the agent is standing on unless it carries an off-mesh link, and
+    /// a zero-length direction normalizes to NaN, which reaches npos through nvel and vel.
+    [Fact]
+    public void CalcSteerDirection_WithACornerOnTheAgent_IsZeroNotNaN()
+    {
+        DtCrowdAgent agent = crowd.AddAgent(startPoss[0], GetAgentParams(0, 0));
+        agent.ncorners = 1;
+        agent.corners[0] = new DtStraightPath(agent.npos, DtStraightPathFlags.DT_STRAIGHTPATH_OFFMESH_CONNECTION, 0);
+
+        Assert.Equal(RcVec3f.Zero, agent.CalcStraightSteerDirection());
+        Assert.Equal(RcVec3f.Zero, agent.CalcSmoothSteerDirection());
+    }
+}

--- a/Recast/Tests/Detour.TileCache/AbstractTileCacheTest.cs
+++ b/Recast/Tests/Detour.TileCache/AbstractTileCacheTest.cs
@@ -38,8 +38,13 @@ public class AbstractTileCacheTest
 
     public DtTileCache GetTileCache(IRcInputGeomProvider geom, RcByteOrder order, bool cCompatibility)
     {
-        DtTileCacheParams option = new DtTileCacheParams();
         RcRecast.CalcTileCount(geom.GetMeshBoundsMin(), geom.GetMeshBoundsMax(), m_cellSize, m_tileSize, m_tileSize, out var tw, out var th);
+        return GetTileCache(geom, order, cCompatibility, tw * th * DtTileCacheLayer.EXPECTED_LAYERS_PER_TILE);
+    }
+
+    public DtTileCache GetTileCache(IRcInputGeomProvider geom, RcByteOrder order, bool cCompatibility, int maxTiles)
+    {
+        DtTileCacheParams option = new DtTileCacheParams();
         option.ch = m_cellHeight;
         option.cs = m_cellSize;
         option.orig = geom.GetMeshBoundsMin();
@@ -49,7 +54,7 @@ public class AbstractTileCacheTest
         option.walkableRadius = m_agentRadius;
         option.walkableClimb = m_agentMaxClimb;
         option.maxSimplificationError = m_edgeMaxError;
-        option.maxTiles = tw * th * DtTileCacheLayer.EXPECTED_LAYERS_PER_TILE;
+        option.maxTiles = maxTiles;
         option.maxObstacles = 128;
 
         DtNavMeshParams navMeshParams = new DtNavMeshParams();

--- a/Recast/Tests/Detour.TileCache/AbstractTileCacheTest.cs
+++ b/Recast/Tests/Detour.TileCache/AbstractTileCacheTest.cs
@@ -42,9 +42,27 @@ public class AbstractTileCacheTest
         return GetTileCache(geom, order, cCompatibility, tw * th * DtTileCacheLayer.EXPECTED_LAYERS_PER_TILE);
     }
 
+    /// A cache on the bordered path — watershed partitioning and height detail, which is what a
+    /// tile's border grid exists for and what Prowl bakes with. The plain cache above leaves both
+    /// off, so it never reads its neighbours' layers at all.
+    public DtTileCache GetBorderedTileCache(IRcInputGeomProvider geom, RcByteOrder order, bool cCompatibility)
+    {
+        RcRecast.CalcTileCount(geom.GetMeshBoundsMin(), geom.GetMeshBoundsMax(), m_cellSize, m_tileSize, m_tileSize, out var tw, out var th);
+        DtTileCache tc = GetTileCache(geom, order, cCompatibility, tw * th * DtTileCacheLayer.EXPECTED_LAYERS_PER_TILE,
+            watershedPartition: true, detailSampleDist: m_cellSize * 6);
+        return tc;
+    }
+
     public DtTileCache GetTileCache(IRcInputGeomProvider geom, RcByteOrder order, bool cCompatibility, int maxTiles)
+        => GetTileCache(geom, order, cCompatibility, maxTiles, watershedPartition: false, detailSampleDist: 0);
+
+    public DtTileCache GetTileCache(IRcInputGeomProvider geom, RcByteOrder order, bool cCompatibility, int maxTiles,
+        bool watershedPartition, float detailSampleDist)
     {
         DtTileCacheParams option = new DtTileCacheParams();
+        option.watershedPartition = watershedPartition;
+        option.detailSampleDist = detailSampleDist;
+        option.detailSampleMaxError = m_cellHeight;
         option.ch = m_cellHeight;
         option.cs = m_cellSize;
         option.orig = geom.GetMeshBoundsMin();

--- a/Recast/Tests/Detour.TileCache/TileCacheParallelBuildTest.cs
+++ b/Recast/Tests/Detour.TileCache/TileCacheParallelBuildTest.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Prowl.Recast.Core;
+using Prowl.Recast.Core.Numerics;
+using Prowl.Recast.Geom;
+
+namespace Prowl.Recast.Detour.TileCache.Tests;
+
+/// Meshing a cache's tiles on several threads at once, which is what registration does. The whole
+/// point is that it changes nothing: the split build must produce the same navmesh the serial one
+/// does, tile for tile.
+public class TileCacheParallelBuildTest : AbstractTileCacheTest
+{
+    private DtTileCache BuildCache(out List<long> refs, bool parallel)
+    {
+        IRcInputGeomProvider geom = RcSampleInputGeomProvider.LoadFile("dungeon.obj");
+        List<byte[]> layers = new TestTileLayerBuilder(geom).Build(RcByteOrder.LITTLE_ENDIAN, true, 1);
+        DtTileCache tc = GetBorderedTileCache(geom, RcByteOrder.LITTLE_ENDIAN, true);
+
+        refs = [];
+        foreach (byte[] data in layers)
+            refs.Add(tc.AddTile(data, 0));
+
+        if (!parallel)
+        {
+            foreach (long r in refs)
+                tc.BuildNavMeshTile(r);
+            return tc;
+        }
+
+        // Build off the navmesh with a scratch per thread, then publish in ref order — the order
+        // is what makes the result identical, since AddTile's neighbour linking follows it.
+        var built = new DtMeshData[refs.Count];
+        List<long> order = refs;
+        Parallel.For(0, refs.Count,
+            () => new DtTileCacheBuildScratch(),
+            (i, _, scratch) =>
+            {
+                built[i] = tc.BuildTileMeshData(order[i], scratch);
+                return scratch;
+            },
+            _ => { });
+
+        for (int i = 0; i < refs.Count; i++)
+            tc.CommitTile(refs[i], built[i]);
+
+        return tc;
+    }
+
+    [Fact]
+    public void ParallelBuild_ProducesTheSameNavMeshAsSerial()
+    {
+        DtTileCache serial = BuildCache(out List<long> serialRefs, parallel: false);
+        DtTileCache parallel = BuildCache(out List<long> parallelRefs, parallel: true);
+        Assert.Equal(serialRefs.Count, parallelRefs.Count);
+
+        DtNavMesh a = serial.GetNavMesh();
+        DtNavMesh b = parallel.GetNavMesh();
+        Assert.Equal(a.GetMaxTiles(), b.GetMaxTiles());
+
+        int compared = 0;
+        for (int t = 0; t < a.GetMaxTiles(); t++)
+        {
+            DtMeshData da = a.GetTile(t)?.data;
+            DtMeshData db = b.GetTile(t)?.data;
+            if (da?.header == null && db?.header == null) continue;
+
+            Assert.NotNull(da?.header);
+            Assert.NotNull(db?.header);
+            Assert.Equal(da.header.x, db.header.x);
+            Assert.Equal(da.header.y, db.header.y);
+            Assert.Equal(da.header.layer, db.header.layer);
+            Assert.Equal(da.header.polyCount, db.header.polyCount);
+            Assert.Equal(da.header.vertCount, db.header.vertCount);
+            Assert.Equal(da.header.detailMeshCount, db.header.detailMeshCount);
+            Assert.Equal(da.header.detailVertCount, db.header.detailVertCount);
+            Assert.Equal(da.header.detailTriCount, db.header.detailTriCount);
+            Assert.Equal(da.header.offMeshConCount, db.header.offMeshConCount);
+            Assert.Equal(da.verts, db.verts);
+            Assert.Equal(da.detailVerts, db.detailVerts);
+            Assert.Equal(da.detailTris, db.detailTris);
+
+            for (int p = 0; p < da.header.polyCount; p++)
+            {
+                Assert.Equal(da.polys[p].vertCount, db.polys[p].vertCount);
+                Assert.Equal(da.polys[p].flags, db.polys[p].flags);
+                Assert.Equal(da.polys[p].GetArea(), db.polys[p].GetArea());
+                Assert.Equal(da.polys[p].verts, db.polys[p].verts);
+                Assert.Equal(da.polys[p].neis, db.polys[p].neis);
+            }
+
+            compared++;
+        }
+
+        Assert.True(compared > 1, $"only {compared} tiles were meshed; the fixture is not exercising this");
+    }
+
+    /// A scratch caches its neighbours' layers, so a scratch held across a carve would build the
+    /// seam from the ground as it used to be — silently, since the tile itself is always
+    /// re-decompressed and only the border would be stale.
+    [Fact]
+    public void ScratchHeldAcrossACarve_DoesNotBuildAStaleSeam()
+    {
+        IRcInputGeomProvider geom = RcSampleInputGeomProvider.LoadFile("dungeon.obj");
+        List<byte[]> layers = new TestTileLayerBuilder(geom).Build(RcByteOrder.LITTLE_ENDIAN, true, 1);
+        DtTileCache tc = GetBorderedTileCache(geom, RcByteOrder.LITTLE_ENDIAN, true);
+
+        var refs = new List<long>();
+        foreach (byte[] data in layers)
+            refs.Add(tc.AddTile(data, 0));
+
+        // Two tiles sharing an edge in X, and the edge itself.
+        long west = 0, east = 0;
+        foreach (long a in refs)
+        {
+            DtTileCacheLayerHeader ha = tc.GetTileByRef(a).header;
+            foreach (long b in refs)
+            {
+                DtTileCacheLayerHeader hb = tc.GetTileByRef(b).header;
+                if (hb.tx != ha.tx + 1 || hb.ty != ha.ty) continue;
+                west = a;
+                east = b;
+                break;
+            }
+
+            if (east != 0) break;
+        }
+
+        Assert.NotEqual(0, east);
+        DtTileCacheLayerHeader wh = tc.GetTileByRef(west).header;
+        DtTileCacheLayerHeader eh = tc.GetTileByRef(east).header;
+
+        var scratch = new DtTileCacheBuildScratch();
+        tc.BuildTileMeshData(east, scratch); // caches the west layer as it is now
+
+        // A block inside the west tile only, within the border strip the east tile reads. On the
+        // east side of the edge it must carve nothing, or the east tile's own carve would erase the
+        // very cells that read the border and the stale layer would not show.
+        float edge = eh.bmin.X;
+        float cs = wh.bmax.X - wh.bmin.X > 0 ? (wh.bmax.X - wh.bmin.X) / wh.width : 0.3f;
+        var min = new RcVec3f(edge - DtTileCacheBuilder.SeamBorder * cs, wh.bmin.Y, wh.bmin.Z);
+        var max = new RcVec3f(edge - 0.01f, wh.bmax.Y, wh.bmax.Z);
+        Assert.NotEqual(0, tc.AddBoxObstacle(min, max));
+        for (int i = 0; i < 8 && !tc.Update(int.MaxValue); i++) { }
+
+        DtMeshData reused = tc.BuildTileMeshData(east, scratch);
+        DtMeshData fresh = tc.BuildTileMeshData(east, new DtTileCacheBuildScratch());
+
+        Assert.Equal(fresh == null, reused == null);
+        if (fresh == null) return;
+        Assert.Equal(fresh.header.vertCount, reused.header.vertCount);
+        Assert.Equal(fresh.header.polyCount, reused.header.polyCount);
+        Assert.Equal(fresh.verts, reused.verts);
+        Assert.Equal(fresh.detailVerts, reused.detailVerts);
+    }
+
+    /// The neighbour-layer cache inside a scratch is what makes a serial bake cheap, and sharing one
+    /// across threads would be the easy mistake. Reusing one scratch across tiles in sequence has to
+    /// stay correct — that is the cache's own path, and the parallel path with one worker.
+    [Fact]
+    public void OneScratchAcrossTiles_MatchesAScratchPerTile()
+    {
+        IRcInputGeomProvider geom = RcSampleInputGeomProvider.LoadFile("dungeon.obj");
+        List<byte[]> layers = new TestTileLayerBuilder(geom).Build(RcByteOrder.LITTLE_ENDIAN, true, 1);
+
+        DtTileCache shared = GetBorderedTileCache(geom, RcByteOrder.LITTLE_ENDIAN, true);
+        DtTileCache fresh = GetBorderedTileCache(geom, RcByteOrder.LITTLE_ENDIAN, true);
+        var sharedRefs = new List<long>();
+        var freshRefs = new List<long>();
+        foreach (byte[] data in layers)
+        {
+            sharedRefs.Add(shared.AddTile(data, 0));
+            freshRefs.Add(fresh.AddTile(data, 0));
+        }
+
+        var oneScratch = new DtTileCacheBuildScratch();
+        for (int i = 0; i < sharedRefs.Count; i++)
+        {
+            shared.CommitTile(sharedRefs[i], shared.BuildTileMeshData(sharedRefs[i], oneScratch));
+            fresh.CommitTile(freshRefs[i], fresh.BuildTileMeshData(freshRefs[i], new DtTileCacheBuildScratch()));
+        }
+
+        for (int t = 0; t < shared.GetNavMesh().GetMaxTiles(); t++)
+        {
+            DtMeshData da = shared.GetNavMesh().GetTile(t)?.data;
+            DtMeshData db = fresh.GetNavMesh().GetTile(t)?.data;
+            if (da?.header == null && db?.header == null) continue;
+            Assert.NotNull(da?.header);
+            Assert.NotNull(db?.header);
+            Assert.Equal(da.header.polyCount, db.header.polyCount);
+            Assert.Equal(da.verts, db.verts);
+            Assert.Equal(da.detailVerts, db.detailVerts);
+        }
+    }
+}

--- a/Recast/Tests/Detour.TileCache/TileCacheParallelBuildTest.cs
+++ b/Recast/Tests/Detour.TileCache/TileCacheParallelBuildTest.cs
@@ -96,6 +96,84 @@ public class TileCacheParallelBuildTest : AbstractTileCacheTest
         Assert.True(compared > 1, $"only {compared} tiles were meshed; the fixture is not exercising this");
     }
 
+    /// A border grid over a buffer grown for a bigger tile has to look exactly like one over an
+    /// exact buffer. The tile fixtures are all one size, so nothing else reaches this: an unreset
+    /// cell would read as ground at whatever height the previous tile had there.
+    [Fact]
+    public void BorderGridOverAnOversizedBuffer_MatchesAnExactOne()
+    {
+        const int border = DtTileCacheBuilder.SeamBorder;
+        int bigCells = (32 + border * 2) * (32 + border * 2);
+        int[] heights = new int[bigCells];
+        int[] areas = new int[bigCells];
+
+        // Fill it as a big tile would have, then hand it back for a small one.
+        var big = new DtTileCacheBuilder.DtTileBorderGrid(32, 32, border, heights, areas);
+        for (int i = 0; i < bigCells; i++)
+        {
+            heights[i] = 7;
+            areas[i] = 3;
+        }
+
+        var reused = new DtTileCacheBuilder.DtTileBorderGrid(8, 8, border, heights, areas);
+        var exact = new DtTileCacheBuilder.DtTileBorderGrid(8, 8, border);
+
+        int smallCells = (8 + border * 2) * (8 + border * 2);
+        for (int i = 0; i < smallCells; i++)
+        {
+            Assert.Equal(exact.heights[i], reused.heights[i]);
+            Assert.Equal(exact.areas[i], reused.areas[i]);
+        }
+
+        Assert.Equal(big.border, reused.border);
+    }
+
+    /// The heightfield's cell array is sized by the tile's cells, and every tile in the fixtures has
+    /// the same count — so nothing else hands a converter a cell buffer grown for a bigger tile.
+    /// Sizes chosen so the second conversion uses a fraction of each buffer.
+    [Fact]
+    public void CompactHeightfieldOverAnOversizedBuffer_MatchesAnExactOne()
+    {
+        var option = new DtTileCacheParams { cs = 0.3f, ch = 0.2f, walkableHeight = 2f, walkableClimb = 0.9f };
+        var scratch = new DtTileCacheBuildScratch();
+
+        // Inflate every pooled buffer on a big grid with ground everywhere, then convert a small one.
+        var big = new DtTileCacheBuilder.DtTileBorderGrid(48, 48, DtTileCacheBuilder.SeamBorder);
+        for (int i = 0; i < big.heights.Length; i++) big.heights[i] = 5;
+        DtTileCacheBuilder.ToCompactHeightfield(big, option, scratch);
+
+        var small = new DtTileCacheBuilder.DtTileBorderGrid(8, 8, DtTileCacheBuilder.SeamBorder);
+        for (int z = 0; z < 8; z++)
+            for (int x = 0; x < 8; x++)
+                small.heights[small.Index(x, z)] = 3;
+
+        RcCompactHeightfield pooled = DtTileCacheBuilder.ToCompactHeightfield(small, option, scratch);
+        RcCompactHeightfield exact = DtTileCacheBuilder.ToCompactHeightfield(small, option, null);
+
+        Assert.Equal(exact.width, pooled.width);
+        Assert.Equal(exact.height, pooled.height);
+        Assert.Equal(exact.spanCount, pooled.spanCount);
+        Assert.Equal(exact.maxDistance, pooled.maxDistance);
+        Assert.Equal(exact.maxRegions, pooled.maxRegions);
+        Assert.Equal(exact.dist, pooled.dist);
+        Assert.True(pooled.spans.Length >= exact.spans.Length, "the buffer was supposed to still be oversized");
+
+        for (int i = 0; i < exact.width * exact.height; i++)
+        {
+            Assert.Equal(exact.cells[i].index, pooled.cells[i].index);
+            Assert.Equal(exact.cells[i].count, pooled.cells[i].count);
+        }
+
+        for (int i = 0; i < exact.spanCount; i++)
+        {
+            Assert.Equal(exact.areas[i], pooled.areas[i]);
+            Assert.Equal(exact.spans[i].y, pooled.spans[i].y);
+            Assert.Equal(exact.spans[i].h, pooled.spans[i].h);
+            Assert.Equal(exact.spans[i].con, pooled.spans[i].con);
+            Assert.Equal(exact.spans[i].reg, pooled.spans[i].reg);
+        }
+    }
+
     /// A scratch caches its neighbours' layers, so a scratch held across a carve would build the
     /// seam from the ground as it used to be — silently, since the tile itself is always
     /// re-decompressed and only the border would be stale.

--- a/Recast/Tests/Detour.TileCache/TileCacheTileLifecycleTest.cs
+++ b/Recast/Tests/Detour.TileCache/TileCacheTileLifecycleTest.cs
@@ -156,9 +156,8 @@ public class TileCacheTileLifecycleTest : AbstractTileCacheTest
         Assert.Equal(0, again);
     }
 
-    /// An obstacle whose footprint covers no compressed layer touches no tile, so the per-tile loop
-    /// that completes an obstacle never runs for it. Without completion it sits in PROCESSING — and
-    /// a removal never reaches EMPTY, leaking the slot for the life of the cache.
+    /// An obstacle whose footprint covers no compressed layer touches no tile, so nothing in the
+    /// per-tile loop completes it: an add stuck in PROCESSING, a remove leaking its slot for good.
     [Fact]
     public void ZeroTouchObstacle_CompletesAndFreesItsSlot()
     {
@@ -175,17 +174,14 @@ public class TileCacheTileLifecycleTest : AbstractTileCacheTest
         Assert.True(tc.Update(8));
         Assert.Equal(DtObstacleState.DT_OBSTACLE_EMPTY, obstacle.state);
 
-        // The freed slot is reusable, and its salt moved on so the old ref cannot resolve to the new
-        // obstacle.
+        // The slot is reusable, and its salt moved on so the old ref cannot resolve to the new one.
         long again = tc.AddObstacle(new RcVec3f(1000f, 0f, 1000f), 1f, 2f);
         Assert.NotEqual(far, again);
         Assert.Same(obstacle, tc.GetObstacleByRef(again));
     }
 
-    /// An obstacle is completed by its OWN last pending tile, not by whichever tile happens to be
-    /// rebuilt next. A request is only drained on an Update with no rebuilds outstanding, so an
-    /// obstacle queued behind one sits in PROCESSING with an empty pending list — and completing it
-    /// there left it PROCESSED holding a list the per-tile loop would never drain again.
+    /// An obstacle is completed by its OWN last pending tile: one still waiting for its request has an
+    /// empty pending list, and completing it early leaves it PROCESSED with a list nothing drains.
     [Fact]
     public void ObstacleAwaitingItsRequest_IsNotCompletedByAnotherTilesRebuild()
     {
@@ -196,8 +192,7 @@ public class TileCacheTileLifecycleTest : AbstractTileCacheTest
         Assert.False(tc.Update(1));
         Assert.NotEmpty(tc.GetObstacleByRef(wide).pending);
 
-        // Queued behind those rebuilds: its own request cannot be drained yet, so it has been told
-        // nothing about which tiles it touches.
+        // Queued behind those rebuilds: its request cannot be drained, so it knows no tiles yet.
         long queued = tc.AddObstacle(new RcVec3f(-1.815208f, 9.998184f, -20.307983f), 1f, 2f);
         DtTileCacheObstacle obstacle = tc.GetObstacleByRef(queued);
         Assert.Equal(DtObstacleState.DT_OBSTACLE_PROCESSING, obstacle.state);
@@ -207,7 +202,6 @@ public class TileCacheTileLifecycleTest : AbstractTileCacheTest
         Assert.False(tc.Update(1));
         Assert.Equal(DtObstacleState.DT_OBSTACLE_PROCESSING, obstacle.state);
 
-        // Once its own request is drained and its tiles built, it completes with nothing left over.
         while (!tc.Update(8))
         {
         }
@@ -216,9 +210,9 @@ public class TileCacheTileLifecycleTest : AbstractTileCacheTest
         Assert.Empty(obstacle.pending);
     }
 
-    /// The reachable consequence: an obstacle placed over a column with no layer, then a layer added
-    /// there. RefreshObstacleTouchedTiles skips anything not PROCESSED, so only a completed obstacle
-    /// picks the new tile up — and Prowl's tile-replacement path depends on exactly that listing.
+    /// RefreshObstacleTouchedTiles skips anything not PROCESSED, so an obstacle over an empty column
+    /// picks up a layer that arrives there later only if it was completed — which Prowl's
+    /// tile-replacement path depends on.
     [Fact]
     public void ObstacleOverAnUnbakedColumn_ListsTheTileThatArrives()
     {
@@ -242,13 +236,13 @@ public class TileCacheTileLifecycleTest : AbstractTileCacheTest
         Assert.Empty(obstacle.pending);
         Assert.Equal(DtObstacleState.DT_OBSTACLE_PROCESSED, obstacle.state);
 
-        // The layer arrives. Neither the add nor the refresh queues a build, so Prowl asks for one
-        // itself; what matters here is that the obstacle now knows about the tile.
+        // Neither the add nor the refresh queues a build; what matters is that the obstacle lists it.
         Assert.True(tc.TryAddTile(data, 0, out long arrived));
         Assert.NotEqual(0, arrived);
         tc.RefreshObstacleTouchedTiles();
         Assert.Contains(arrived, obstacle.touched);
     }
+
     /// The refresh has to widen by the seam border exactly as the add path does: a tile an obstacle
     /// reaches only through that border still carves it, and would otherwise be dropped from the
     /// obstacle's list the first time it was replaced.

--- a/Recast/Tests/Detour.TileCache/TileCacheTileLifecycleTest.cs
+++ b/Recast/Tests/Detour.TileCache/TileCacheTileLifecycleTest.cs
@@ -156,6 +156,99 @@ public class TileCacheTileLifecycleTest : AbstractTileCacheTest
         Assert.Equal(0, again);
     }
 
+    /// An obstacle whose footprint covers no compressed layer touches no tile, so the per-tile loop
+    /// that completes an obstacle never runs for it. Without completion it sits in PROCESSING — and
+    /// a removal never reaches EMPTY, leaking the slot for the life of the cache.
+    [Fact]
+    public void ZeroTouchObstacle_CompletesAndFreesItsSlot()
+    {
+        DtTileCache tc = BuildDungeonCache(out _);
+
+        long far = tc.AddObstacle(new RcVec3f(1000f, 0f, 1000f), 1f, 2f);
+        Assert.True(tc.Update(8));
+
+        DtTileCacheObstacle obstacle = tc.GetObstacleByRef(far);
+        Assert.Empty(obstacle.pending);
+        Assert.Equal(DtObstacleState.DT_OBSTACLE_PROCESSED, obstacle.state);
+
+        tc.RemoveObstacle(far);
+        Assert.True(tc.Update(8));
+        Assert.Equal(DtObstacleState.DT_OBSTACLE_EMPTY, obstacle.state);
+
+        // The freed slot is reusable, and its salt moved on so the old ref cannot resolve to the new
+        // obstacle.
+        long again = tc.AddObstacle(new RcVec3f(1000f, 0f, 1000f), 1f, 2f);
+        Assert.NotEqual(far, again);
+        Assert.Same(obstacle, tc.GetObstacleByRef(again));
+    }
+
+    /// An obstacle is completed by its OWN last pending tile, not by whichever tile happens to be
+    /// rebuilt next. A request is only drained on an Update with no rebuilds outstanding, so an
+    /// obstacle queued behind one sits in PROCESSING with an empty pending list — and completing it
+    /// there left it PROCESSED holding a list the per-tile loop would never drain again.
+    [Fact]
+    public void ObstacleAwaitingItsRequest_IsNotCompletedByAnotherTilesRebuild()
+    {
+        DtTileCache tc = BuildDungeonCache(out _);
+
+        // A wide obstacle so its rebuilds outlast one Update slice, leaving the request loop shut.
+        long wide = tc.AddObstacle(new RcVec3f(-1.815208f, 9.998184f, -20.307983f), 25f, 4f);
+        Assert.False(tc.Update(1));
+        Assert.NotEmpty(tc.GetObstacleByRef(wide).pending);
+
+        // Queued behind those rebuilds: its own request cannot be drained yet, so it has been told
+        // nothing about which tiles it touches.
+        long queued = tc.AddObstacle(new RcVec3f(-1.815208f, 9.998184f, -20.307983f), 1f, 2f);
+        DtTileCacheObstacle obstacle = tc.GetObstacleByRef(queued);
+        Assert.Equal(DtObstacleState.DT_OBSTACLE_PROCESSING, obstacle.state);
+        Assert.Empty(obstacle.pending);
+
+        // This slice rebuilds a tile for the FIRST obstacle. That must not complete the second.
+        Assert.False(tc.Update(1));
+        Assert.Equal(DtObstacleState.DT_OBSTACLE_PROCESSING, obstacle.state);
+
+        // Once its own request is drained and its tiles built, it completes with nothing left over.
+        while (!tc.Update(8))
+        {
+        }
+
+        Assert.Equal(DtObstacleState.DT_OBSTACLE_PROCESSED, obstacle.state);
+        Assert.Empty(obstacle.pending);
+    }
+
+    /// The reachable consequence: an obstacle placed over a column with no layer, then a layer added
+    /// there. RefreshObstacleTouchedTiles skips anything not PROCESSED, so only a completed obstacle
+    /// picks the new tile up — and Prowl's tile-replacement path depends on exactly that listing.
+    [Fact]
+    public void ObstacleOverAnUnbakedColumn_ListsTheTileThatArrives()
+    {
+        DtTileCache tc = BuildDungeonCache(out List<long> refs);
+        long target = FindMeshedTile(tc, refs);
+        Assert.NotEqual(0, target);
+
+        DtTileCacheLayerHeader header = tc.GetTileByRef(target).header;
+        byte[] data = tc.GetTileByRef(target).data;
+        float cs = tc.GetParams().cs;
+        var centre = new RcVec3f(
+            header.bmin.X + (header.minx + header.maxx + 1) * 0.5f * cs,
+            header.bmin.Y + 1f,
+            header.bmin.Z + (header.miny + header.maxy + 1) * 0.5f * cs);
+
+        // Empty the column, then place the obstacle over it: nothing for it to touch.
+        tc.RemoveTile(target);
+        long obstacleRef = tc.AddObstacle(centre, 1f, 2f);
+        Assert.True(tc.Update(8));
+        DtTileCacheObstacle obstacle = tc.GetObstacleByRef(obstacleRef);
+        Assert.Empty(obstacle.pending);
+        Assert.Equal(DtObstacleState.DT_OBSTACLE_PROCESSED, obstacle.state);
+
+        // The layer arrives. Neither the add nor the refresh queues a build, so Prowl asks for one
+        // itself; what matters here is that the obstacle now knows about the tile.
+        Assert.True(tc.TryAddTile(data, 0, out long arrived));
+        Assert.NotEqual(0, arrived);
+        tc.RefreshObstacleTouchedTiles();
+        Assert.Contains(arrived, obstacle.touched);
+    }
     /// The refresh has to widen by the seam border exactly as the add path does: a tile an obstacle
     /// reaches only through that border still carves it, and would otherwise be dropped from the
     /// obstacle's list the first time it was replaced.

--- a/Recast/Tests/Detour.TileCache/TileCacheTileLifecycleTest.cs
+++ b/Recast/Tests/Detour.TileCache/TileCacheTileLifecycleTest.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using Prowl.Recast.Core;
+using Prowl.Recast.Core.Numerics;
+using Prowl.Recast.Geom;
+
+namespace Prowl.Recast.Detour.TileCache.Tests;
+
+/// Tiles removed and replaced while the cache is live, which a cache built once and never touched
+/// again does not exercise.
+public class TileCacheTileLifecycleTest : AbstractTileCacheTest
+{
+    private static List<byte[]> BuildDungeonLayers(out IRcInputGeomProvider geom)
+    {
+        geom = RcSampleInputGeomProvider.LoadFile("dungeon.obj");
+        return new TestTileLayerBuilder(geom).Build(RcByteOrder.LITTLE_ENDIAN, true, 1);
+    }
+
+    private DtTileCache BuildDungeonCache(out List<long> refs)
+    {
+        List<byte[]> layers = BuildDungeonLayers(out IRcInputGeomProvider geom);
+        DtTileCache tc = GetTileCache(geom, RcByteOrder.LITTLE_ENDIAN, true);
+        refs = [];
+        foreach (byte[] data in layers)
+        {
+            long r = tc.AddTile(data, 0);
+            tc.BuildNavMeshTile(r);
+            refs.Add(r);
+        }
+
+        return tc;
+    }
+
+    /// A layer that produced navmesh polygons; an empty one leaves nothing behind to assert on.
+    private static long FindMeshedTile(DtTileCache tc, List<long> refs)
+    {
+        foreach (long r in refs)
+        {
+            DtTileCacheLayerHeader header = tc.GetTileByRef(r).header;
+            if (tc.GetNavMesh().GetTileRefAt(header.tx, header.ty, header.tlayer) != 0)
+            {
+                return r;
+            }
+        }
+
+        return 0;
+    }
+
+    [Fact]
+    public void RemoveTile_AlsoRemovesTheNavMeshTile()
+    {
+        DtTileCache tc = BuildDungeonCache(out List<long> refs);
+        long meshed = FindMeshedTile(tc, refs);
+        Assert.NotEqual(0, meshed);
+        DtTileCacheLayerHeader header = tc.GetTileByRef(meshed).header;
+
+        tc.RemoveTile(meshed);
+
+        Assert.Null(tc.GetTileByRef(meshed));
+        Assert.Equal(0, tc.GetNavMesh().GetTileRefAt(header.tx, header.ty, header.tlayer));
+    }
+
+    [Fact]
+    public void RemoveCompressedTileOnly_LeavesTheNavMeshTile()
+    {
+        DtTileCache tc = BuildDungeonCache(out List<long> refs);
+        long meshed = FindMeshedTile(tc, refs);
+        Assert.NotEqual(0, meshed);
+        DtTileCacheLayerHeader header = tc.GetTileByRef(meshed).header;
+
+        tc.RemoveCompressedTileOnly(meshed);
+
+        Assert.Null(tc.GetTileByRef(meshed));
+        Assert.NotEqual(0, tc.GetNavMesh().GetTileRefAt(header.tx, header.ty, header.tlayer));
+    }
+
+    [Fact]
+    public void TryAddTile_WhenTheTilePoolIsExhausted_ReturnsFalse()
+    {
+        List<byte[]> layers = BuildDungeonLayers(out IRcInputGeomProvider geom);
+        Assert.True(layers.Count > 1);
+        DtTileCache tc = GetTileCache(geom, RcByteOrder.LITTLE_ENDIAN, true, 1);
+
+        Assert.True(tc.TryAddTile(layers[0], 0, out long first));
+        Assert.NotEqual(0, first);
+
+        bool exhausted = false;
+        int firstRefused = -1;
+        for (int i = 1; i < layers.Count && !exhausted; i++)
+        {
+            exhausted = !tc.TryAddTile(layers[i], 0, out _);
+            if (exhausted) firstRefused = i;
+        }
+
+        Assert.True(exhausted);
+        // AddTile keeps throwing where TryAddTile reports, so package consumers see no change.
+        Assert.Throws<Exception>(() => tc.AddTile(layers[firstRefused], 0));
+    }
+
+    /// A tile removed while its rebuild is still queued: the salt bump makes the queued ref name a
+    /// tile that no longer exists, and building it throws.
+    [Fact]
+    public void RemoveTile_WithARebuildStillQueued_DoesNotThrowOnTheNextUpdate()
+    {
+        DtTileCache tc = BuildDungeonCache(out _);
+        tc.AddObstacle(new RcVec3f(-1.815208f, 9.998184f, -20.307983f), 25f, 4f);
+        tc.Update(1);
+
+        DtTileCacheObstacle obstacle = tc.GetObstacle(0);
+        Assert.NotEmpty(obstacle.pending);
+        long queued = obstacle.pending[0];
+
+        tc.RemoveTile(queued);
+
+        Assert.DoesNotContain(queued, obstacle.pending);
+        Assert.DoesNotContain(queued, obstacle.touched);
+        while (!tc.Update(8))
+        {
+        }
+
+        Assert.Equal(DtObstacleState.DT_OBSTACLE_PROCESSED, obstacle.state);
+    }
+
+    /// Removing an obstacle's last pending tile has to complete it: the update loop can no longer
+    /// do that, and a REMOVING obstacle would keep its slot forever.
+    [Fact]
+    public void RemoveTile_CompletesAnObstacleWhoseLastPendingTileGoes()
+    {
+        DtTileCache tc = BuildDungeonCache(out _);
+        long obstacleRef = tc.AddObstacle(new RcVec3f(-1.815208f, 9.998184f, -20.307983f), 25f, 4f);
+        while (!tc.Update(8))
+        {
+        }
+
+        DtTileCacheObstacle obstacle = tc.GetObstacle(0);
+        tc.RemoveObstacle(obstacleRef);
+        tc.Update(1);
+        Assert.Equal(DtObstacleState.DT_OBSTACLE_REMOVING, obstacle.state);
+        Assert.NotEmpty(obstacle.pending);
+
+        while (obstacle.pending.Count > 0)
+        {
+            tc.RemoveTile(obstacle.pending[0]);
+        }
+
+        Assert.Equal(DtObstacleState.DT_OBSTACLE_EMPTY, obstacle.state);
+    }
+
+    [Fact]
+    public void TryAddTile_WhenThePositionIsTaken_SucceedsWithNoRef()
+    {
+        DtTileCache tc = BuildDungeonCache(out List<long> refs);
+        byte[] data = tc.GetTileByRef(refs[0]).data;
+
+        Assert.True(tc.TryAddTile(data, 0, out long again));
+        Assert.Equal(0, again);
+    }
+
+    /// The refresh has to widen by the seam border exactly as the add path does: a tile an obstacle
+    /// reaches only through that border still carves it, and would otherwise be dropped from the
+    /// obstacle's list the first time it was replaced.
+    [Fact]
+    public void RefreshObstacleTouchedTiles_ReListsATileTouchedOnlyThroughItsSeamBorder()
+    {
+        DtTileCache tc = BuildDungeonCache(out List<long> refs);
+        long target = FindMeshedTile(tc, refs);
+        Assert.NotEqual(0, target);
+
+        DtTileCacheLayerHeader header = tc.GetTileByRef(target).header;
+        float cs = tc.GetParams().cs;
+        float reach = DtTileCacheBuilder.SeamBorder * cs;
+
+        // Just past the tile's own extent, inside the border it still reads.
+        float edgeX = header.bmin.X + (header.maxx + 1) * cs;
+        float centreZ = header.bmin.Z + (header.miny + header.maxy) * 0.5f * cs;
+        var beyond = new RcVec3f(edgeX + reach * 0.5f, (header.bmin.Y + header.bmax.Y) * 0.5f, centreZ);
+
+        tc.AddObstacle(beyond, 0.1f, 2f);
+        while (!tc.Update(8))
+        {
+        }
+
+        DtTileCacheObstacle obstacle = tc.GetObstacle(0);
+        Assert.Equal(DtObstacleState.DT_OBSTACLE_PROCESSED, obstacle.state);
+        Assert.Contains(target, obstacle.touched);
+
+        byte[] data = tc.GetTileByRef(target).data;
+        tc.RemoveTile(target);
+        Assert.True(tc.TryAddTile(data, 0, out long replaced));
+        Assert.DoesNotContain(replaced, obstacle.touched);
+
+        tc.RefreshObstacleTouchedTiles();
+
+        Assert.Contains(replaced, obstacle.touched);
+
+        // And the listing is what actually puts the carve back: rebuilt after the refresh, the
+        // replacement tile carries the obstacle again.
+        tc.BuildNavMeshTile(replaced);
+        Assert.NotEqual(0, tc.GetNavMesh().GetTileRefAt(header.tx, header.ty, header.tlayer));
+    }
+}

--- a/Recast/Tests/Prowl.Recast.Tests.csproj
+++ b/Recast/Tests/Prowl.Recast.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
This change makes the following adjustments used by the NavMesh PR:

- Tiles can be replaced live without a queued rebuild throwing on the next update, and an agent can be teleported without invalidating references held to it.
- Tile builds split so several tiles can be meshed at once, producing output byte-identical to a serial build.
- Pools the tile build's working buffers: 196.9 KB down to 107.6 KB per tile build, a cost every carve was paying.
- An obstacle whose footprint covers no baked tile now completes instead of sitting in its pending state forever, and Recast's own logging routes to the host engine instead of stdout.
- A lost move target now clears the agent's desired velocity, so a carved-away destination no longer leaves it walking forever.
- A steer direction that collapses to zero no longer produces NaN agent positions.